### PR TITLE
test: loom tests only print traces from the failed iteration

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,17 +1,22 @@
 macro_rules! test_println {
     ($($arg:tt)*) => {
-        if cfg!(test) {
+        if cfg!(test) || cfg!(all(thingbuf_trace, feature = "std")) {
             if crate::util::panic::panicking() {
                 // getting the thread ID while panicking doesn't seem to play super nicely with loom's
                 // mock lazy_static...
-                println!("[PANIC {:>17}:{:<3}] {}", file!(), line!(), format_args!($($arg)*))
+                println!("[PANIC {:>30}:{:<3}] {}", file!(), line!(), format_args!($($arg)*))
             } else {
-                println!("[{:?} {:>17}:{:<3}] {}", crate::loom::thread::current().id(), file!(), line!(), format_args!($($arg)*))
+                crate::loom::traceln(format_args!(
+                    "[{:?} {:>30}:{:<3}] {}",
+                    crate::loom::thread::current().id(),
+                    file!(),
+                    line!(),
+                    format_args!($($arg)*),
+                ));
             }
         }
     }
 }
-
 macro_rules! test_dbg {
     ($e:expr) => {
         match $e {


### PR DESCRIPTION
This helps a *lot* when a test fails on the 300,000th iteration or
something; you don't have to wait for *every* previous iteration's trace
to be dumped to stdout.