### PR TITLE
feat: add `Deref` and `DerefMut` impls to `Ref` types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1.14.0", features = ["rt", "rt-multi-thread", "macros", "sy
 futures-util = { version = "0.3", default-features = false }
 
 [target.'cfg(loom)'.dev-dependencies]
-loom = { version = "0.5.3", features = ["checkpoint", "futures"] }
+loom = { version = "0.5.4", features = ["checkpoint", "futures"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "fmt"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,3 @@
   "ringbuf"), I called it "stringbuf". Then, I realized you could do this with
   more than just strings. In fact, it can be generalized to arbitrary...things.
   So, "thingbuf".
-
-- **Q: Why don't the `Ref` types implement `Deref` and `DerefMut`?**
-
-  **A:** [Blame `loom` for this.](https://github.com/tokio-rs/loom/pull/219)

--- a/src/loom.rs
+++ b/src/loom.rs
@@ -8,7 +8,7 @@ mod inner {
         pub use std::sync::atomic::Ordering;
     }
 
-    pub(crate) use loom::{cell::UnsafeCell, future, hint, sync, thread};
+    pub(crate) use loom::{cell, future, hint, sync, thread};
     use std::{cell::RefCell, fmt::Write};
 
     pub(crate) mod model {
@@ -213,31 +213,59 @@ mod inner {
         }
     }
 
-    #[derive(Debug)]
-    pub(crate) struct UnsafeCell<T>(core::cell::UnsafeCell<T>);
+    pub(crate) mod cell {
+        #[derive(Debug)]
+        pub(crate) struct UnsafeCell<T>(core::cell::UnsafeCell<T>);
 
-    impl<T> UnsafeCell<T> {
-        pub const fn new(data: T) -> UnsafeCell<T> {
-            UnsafeCell(core::cell::UnsafeCell::new(data))
+        impl<T> UnsafeCell<T> {
+            pub const fn new(data: T) -> UnsafeCell<T> {
+                UnsafeCell(core::cell::UnsafeCell::new(data))
+            }
+
+            #[inline(always)]
+            pub fn with<F, R>(&self, f: F) -> R
+            where
+                F: FnOnce(*const T) -> R,
+            {
+                f(self.0.get())
+            }
+
+            #[inline(always)]
+            pub fn with_mut<F, R>(&self, f: F) -> R
+            where
+                F: FnOnce(*mut T) -> R,
+            {
+                f(self.0.get())
+            }
+
+            #[inline(always)]
+            pub(crate) fn get_mut(&self) -> MutPtr<T> {
+                MutPtr(self.0.get())
+            }
         }
 
-        #[inline(always)]
-        pub fn with<F, R>(&self, f: F) -> R
-        where
-            F: FnOnce(*const T) -> R,
-        {
-            f(self.0.get())
-        }
+        #[derive(Debug)]
+        pub(crate) struct MutPtr<T: ?Sized>(*mut T);
 
-        #[inline(always)]
-        pub fn with_mut<F, R>(&self, f: F) -> R
-        where
-            F: FnOnce(*mut T) -> R,
-        {
-            f(self.0.get())
+        impl<T: ?Sized> MutPtr<T> {
+            // Clippy knows that it's Bad and Wrong to construct a mutable reference
+            // from an immutable one...but this function is intended to simulate a raw
+            // pointer, so we have to do that here.
+            #[allow(clippy::mut_from_ref)]
+            #[inline(always)]
+            pub(crate) unsafe fn deref(&self) -> &mut T {
+                &mut *self.0
+            }
+
+            #[inline(always)]
+            pub fn with<F, R>(&self, f: F) -> R
+            where
+                F: FnOnce(*mut T) -> R,
+            {
+                f(self.0)
+            }
         }
     }
-
     pub(crate) mod alloc {
         /// Track allocations, detecting leaks
         #[derive(Debug, Default)]

--- a/src/mpsc/async_impl.rs
+++ b/src/mpsc/async_impl.rs
@@ -151,8 +151,8 @@ impl<T: Default> Receiver<T> {
     pub fn poll_recv_ref(&self, cx: &mut Context<'_>) -> Poll<Option<RecvRef<'_, T>>> {
         self.inner.poll_recv_ref(|| cx.waker().clone()).map(|some| {
             some.map(|slot| RecvRef {
+                _notify: super::NotifyTx(&self.inner.tx_wait),
                 slot,
-                inner: &*self.inner,
             })
         })
     }

--- a/src/mpsc/sync.rs
+++ b/src/mpsc/sync.rs
@@ -107,8 +107,8 @@ impl<T: Default> Receiver<T> {
             match self.inner.poll_recv_ref(thread::current) {
                 Poll::Ready(r) => {
                     return r.map(|slot| RecvRef {
+                        _notify: super::NotifyTx(&self.inner.tx_wait),
                         slot,
-                        inner: &*self.inner,
                     })
                 }
                 Poll::Pending => {

--- a/src/mpsc/tests/mpsc_sync.rs
+++ b/src/mpsc/tests/mpsc_sync.rs
@@ -21,12 +21,12 @@ fn mpsc_try_send_recv() {
         let p1 = {
             let tx = tx.clone();
             thread::spawn(move || {
-                tx.try_send_ref().unwrap().with_mut(|val| *val = 1);
+                *tx.try_send_ref().unwrap() = 1;
             })
         };
         let p2 = thread::spawn(move || {
-            tx.try_send(2).unwrap();
-            tx.try_send(3).unwrap();
+            *tx.try_send_ref().unwrap() = 2;
+            *tx.try_send_ref().unwrap() = 3;
         });
 
         let mut vals = Vec::new();
@@ -53,8 +53,11 @@ fn rx_closes() {
             'iters: for i in 0..=ITERATIONS {
                 test_println!("sending {}", i);
                 'send: loop {
-                    match tx.try_send(i) {
-                        Ok(_) => break 'send,
+                    match tx.try_send_ref() {
+                        Ok(mut slot) => {
+                            *slot = i;
+                            break 'send;
+                        }
                         Err(TrySendError::Full(_)) => thread::yield_now(),
                         Err(TrySendError::Closed(_)) => break 'iters,
                     }

--- a/src/util/wait/wait_cell.rs
+++ b/src/util/wait/wait_cell.rs
@@ -5,7 +5,7 @@ use crate::{
             AtomicUsize,
             Ordering::{self, *},
         },
-        UnsafeCell,
+        cell::UnsafeCell,
     },
     util::panic::{self, RefUnwindSafe, UnwindSafe},
 };

--- a/src/util/wait/wait_queue.rs
+++ b/src/util/wait/wait_queue.rs
@@ -5,7 +5,7 @@ use crate::{
             AtomicUsize,
             Ordering::{self, *},
         },
-        UnsafeCell,
+        cell::UnsafeCell,
     },
     util::{panic, Backoff, CachePadded},
 };


### PR DESCRIPTION
Now that tokio-rs/loom#219 has merged, we can add
`Deref`/`DerefMut` for the `Ref` types without breaking
Loom's concurrent access checking! :D

This makes the `Ref` APIs much easier to work with.