### PR TITLE
fix(mpsc): fix a deadlock in async send_ref 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ impl Core {
     }
 
     fn close(&self) -> bool {
+        test_println!("Core::close");
         if std::thread::panicking() {
             return false;
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -21,7 +21,7 @@ macro_rules! test_dbg {
     ($e:expr) => {
         match $e {
             e => {
-                #[cfg(test)]
+                #[cfg(any(test, all(thingbuf_trace, feature = "std")))]
                 test_println!("{} = {:?}", stringify!($e), &e);
                 e
             }

--- a/src/mpsc.rs
+++ b/src/mpsc.rs
@@ -121,7 +121,7 @@ impl<T: Default, N: Notify + Unpin> Inner<T, N> {
     fn poll_send_ref(
         &self,
         node: Pin<&mut queue::Waiter<N>>,
-        mut register: impl FnMut(&mut Option<N>) -> bool,
+        mut register: impl FnMut(&mut Option<N>),
     ) -> Poll<Result<SendRefInner<'_, T, N>, Closed>> {
         let mut backoff = Backoff::new();
         let mut node = Some(node);

--- a/src/mpsc/sync.rs
+++ b/src/mpsc/sync.rs
@@ -65,11 +65,14 @@ impl<T: Default> Sender<T> {
                 // be moved while this thread is parked.
                 Pin::new_unchecked(&mut waiter)
             };
-            if let Poll::Ready(result) = self.inner.poll_send_ref(Some(waiter), |thread| {
+            if let Poll::Ready(result) = self.inner.poll_send_ref(waiter, |thread| {
                 if thread.is_none() {
                     let current = thread::current();
                     test_println!("registering {:?}", current);
                     *thread = Some(current);
+                    true
+                } else {
+                    false
                 }
             }) {
                 return result.map(SendRef);

--- a/src/mpsc/sync.rs
+++ b/src/mpsc/sync.rs
@@ -70,9 +70,6 @@ impl<T: Default> Sender<T> {
                     let current = thread::current();
                     test_println!("registering {:?}", current);
                     *thread = Some(current);
-                    true
-                } else {
-                    false
                 }
             }) {
                 return result.map(SendRef);

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -94,7 +94,6 @@ struct Node<T> {
     next: Link<Waiter<T>>,
     prev: Link<Waiter<T>>,
     waiter: Option<T>,
-    is_notified: bool,
 
     // This type is !Unpin due to the heuristic from:
     // <https://github.com/rust-lang/rust/pull/82834>
@@ -197,7 +196,7 @@ impl<T: Notify + Unpin> WaitQueue<T> {
             if let Some(waiter) = waiter.take() {
                 // Now that we have the lock, register the `Waker` or `Thread`
                 // to
-                let (should_queue, is_notified) = unsafe {
+                let should_queue = unsafe {
                     test_println!("WaitQueue::push_waiter -> registering {:p}", waiter);
                     // Safety: the waker can only be registered while holding
                     // the wait queue lock. We are holding the lock, so no one
@@ -210,20 +209,11 @@ impl<T: Notify + Unpin> WaitQueue<T> {
                         // the first time, or it is re-registering after a
                         // notification that it wasn't able to consume (for some
                         // reason).
-                        if test_dbg!(node.is_notified) {
-                            return (false, true);
-                        }
-
-                        let should_queue = test_dbg!(node.waiter.is_none());
+                        let should_queue = node.waiter.is_none();
                         register(&mut node.waiter);
-                        (should_queue, false)
+                        should_queue
                     })
                 };
-
-                if test_dbg!(is_notified) {
-                    return WaitResult::Notified;
-                }
-
                 if test_dbg!(should_queue) {
                     test_println!("WaitQueue::push_waiter -> pushing {:p}", waiter);
                     list.push_front(waiter);
@@ -277,7 +267,6 @@ impl<T: Notify> Waiter<T> {
                 next: None,
                 prev: None,
                 waiter: None,
-                is_notified: false,
                 _pin: PhantomPinned,
             }),
         }
@@ -285,12 +274,7 @@ impl<T: Notify> Waiter<T> {
 
     #[inline]
     fn notify(self: Pin<&mut Self>) -> bool {
-        let waker = unsafe {
-            self.with_node(|node| {
-                node.is_notified = true;
-                node.waiter.take()
-            })
-        };
+        let waker = unsafe { self.with_node(|node| node.waiter.take()) };
         // Wake *outside* of the `with_node` closure, in case waking the
         // thread/task results in it immediately trying to access its node, and
         // loom doesn't realize that we're done accessing the shared state.


### PR DESCRIPTION
This fixes a deadlock issue in the async MPSC's `send_ref` method. The
deadlock occurs when a new waker needs to be registered for a task whose
wait node is already in the wait queue. Previously, the new waker would
not be registered because the waker registering closure was only called
when the node was being enqueued. If the node was already in the queue,
polling the future would never touch the waker. This means that if the
task was polled with a new waker, it would leave its old waker in the
queue, and might never be notified again.

This branch fixes that by separating pushing the task and registering
the waker. We check if the node already has a waker prior to registering,
and if it did, we don't push it again.