### PR TITLE
perf(mpsc): rewrite and optimize wait queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default = ["std"]
 
 [dependencies]
 pin-project = "1"
+parking_lot = { version = "0.11", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.14.0", features = ["rt", "rt-multi-thread", "macros", "sync"] }

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -7,18 +7,22 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["parking_lot"]
 # These feature flags can be disabled if we don't want to run comparison
 # benchmarks, such as when just comparing two `thingbuf` versions.
 comparisons = ["crossbeam", "async-std", "futures", "tokio-sync", "std-sync"]
 tokio-sync = ["tokio/sync"]
 std-sync = []
 
+# Use parking_lot mutexes in `thingbuf` 
+parking_lot = ["thingbuf/parking_lot"]
+
 [dependencies]
 thingbuf = { path = ".." }
 criterion = { version = "0.3.5", features = ["async_tokio"] }
 
 # for comparison benchmarks
-tokio = { version = "1.14.0", features = ["rt", "rt-multi-thread", "sync"] }
+tokio = { version = "1.14.0", features = ["rt", "rt-multi-thread", "sync", "parking_lot"] }
 crossbeam = { version = "0.8.1", optional = true }
 async-std = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ impl Core {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     fn idx_gen(&self, val: usize) -> (usize, usize) {
         (val & self.idx_mask, val & self.gen_mask)
     }
@@ -138,6 +138,7 @@ impl Core {
         test_dbg!(self.tail.fetch_or(self.closed, SeqCst) & self.closed == 0)
     }
 
+    #[inline(always)]
     fn push_ref<'slots, T, S>(
         &self,
         slots: &'slots S,
@@ -226,6 +227,7 @@ impl Core {
         }
     }
 
+    #[inline(always)]
     fn pop_ref<'slots, T, S>(&self, slots: &'slots S) -> Result<Ref<'slots, T>, mpsc::TrySendError>
     where
         S: ops::Index<usize, Output = Slot<T>> + ?Sized,

--- a/src/mpsc.rs
+++ b/src/mpsc.rs
@@ -125,35 +125,7 @@ impl<T: Default, N: Notify + Unpin> Inner<T, N> {
     ) -> Poll<Result<SendRefInner<'_, T, N>, Closed>> {
         let mut backoff = Backoff::new();
         let mut node = Some(node);
-        // try to send a few times in a loop, in case the receiver notifies us
-        // right before we park.
-        loop {
-            // try to reserve a send slot, returning if we succeeded or if the
-            // queue was closed.
-            match self.try_send_ref() {
-                Ok(slot) => return Poll::Ready(Ok(slot)),
-                Err(TrySendError::Closed(_)) => return Poll::Ready(Err(Closed(()))),
-                Err(_) => {}
-            }
-
-            // try to push a waiter
-            let pushed_waiter = self.tx_wait.wait(&mut node, &mut register);
-
-            match test_dbg!(pushed_waiter) {
-                WaitResult::Closed => {
-                    // the channel closed while we were registering the waiter!
-                    return Poll::Ready(Err(Closed(())));
-                }
-                WaitResult::Wait => {
-                    // okay, we are now queued to wait. gotosleep!
-                    return Poll::Pending;
-                }
-                WaitResult::Notified => {
-                    // we consumed a queued notification. try again...
-                    backoff.spin_yield();
-                }
-            }
-        }
+        unimplemented!()
     }
 
     /// Performs one iteration of the `recv_ref` loop.

--- a/src/mpsc.rs
+++ b/src/mpsc.rs
@@ -12,7 +12,7 @@
 
 use crate::{
     loom::{atomic::AtomicUsize, hint},
-    wait::{queue, Notify, WaitCell, WaitQueue, WaitResult},
+    wait::{Notify, WaitCell, WaitQueue, WaitResult},
     Ref, ThingBuf,
 };
 use core::fmt;
@@ -110,19 +110,6 @@ impl<T: Default, N: Notify + Unpin> Inner<T, N> {
             }
             Err(e) => Err(e.with_value(val)),
         }
-    }
-
-    /// Performs one iteration of the `send_ref` loop.
-    ///
-    /// The loop itself has to be written in the actual `send` method's
-    /// implementation, rather than on `inner`, because it might be async and
-    /// may yield, or might park the thread.
-    fn poll_send_ref(
-        &self,
-        _node: Pin<&mut queue::Waiter<N>>,
-        _register: impl FnMut(&mut Option<N>),
-    ) -> Poll<Result<SendRefInner<'_, T, N>, Closed>> {
-        unimplemented!()
     }
 
     /// Performs one iteration of the `recv_ref` loop.

--- a/src/mpsc.rs
+++ b/src/mpsc.rs
@@ -12,7 +12,6 @@
 
 use crate::{
     loom::{atomic::AtomicUsize, hint},
-    util::Backoff,
     wait::{queue, Notify, WaitCell, WaitQueue, WaitResult},
     Ref, ThingBuf,
 };
@@ -120,11 +119,9 @@ impl<T: Default, N: Notify + Unpin> Inner<T, N> {
     /// may yield, or might park the thread.
     fn poll_send_ref(
         &self,
-        node: Pin<&mut queue::Waiter<N>>,
-        mut register: impl FnMut(&mut Option<N>),
+        _node: Pin<&mut queue::Waiter<N>>,
+        _register: impl FnMut(&mut Option<N>),
     ) -> Poll<Result<SendRefInner<'_, T, N>, Closed>> {
-        let mut backoff = Backoff::new();
-        let mut node = Some(node);
         unimplemented!()
     }
 

--- a/src/mpsc/async_impl.rs
+++ b/src/mpsc/async_impl.rs
@@ -157,7 +157,7 @@ impl<T: Default> Sender<T> {
             fn drop(self: Pin<&mut Self>) {
                 test_println!("SendRefFuture::drop({:p})", self);
                 let this = self.project();
-                if test_dbg!(*this.state) == State::Waiting {
+                if test_dbg!(*this.state) == State::Waiting && test_dbg!(this.waiter.is_linked()) {
                     this.waiter.remove(&this.tx.inner.tx_wait)
                 }
             }

--- a/src/mpsc/async_impl.rs
+++ b/src/mpsc/async_impl.rs
@@ -108,11 +108,7 @@ impl<T: Default> Sender<T> {
                                 Err(_) => {}
                             }
 
-                            let start_wait = this.tx.inner.tx_wait.start_wait(node, || {
-                                let waker = cx.waker().clone();
-                                test_println!("SendRefFuture::poll -> initial waker {:?}", waker);
-                                waker
-                            });
+                            let start_wait = this.tx.inner.tx_wait.start_wait(node, cx.waker());
 
                             match test_dbg!(start_wait) {
                                 WaitResult::Closed => {
@@ -131,16 +127,7 @@ impl<T: Default> Sender<T> {
                         }
                         State::Waiting => {
                             let continue_wait =
-                                this.tx.inner.tx_wait.continue_wait(node, |waker| {
-                                    let my_waker = cx.waker();
-                                    if test_dbg!(!waker.will_wake(my_waker)) {
-                                        test_println!(
-                                            "poll_send_ref -> re-registering waker {:?}",
-                                            my_waker
-                                        );
-                                        *waker = my_waker.clone();
-                                    }
-                                });
+                                this.tx.inner.tx_wait.continue_wait(node, cx.waker());
 
                             match test_dbg!(continue_wait) {
                                 WaitResult::Closed => {

--- a/src/mpsc/sync.rs
+++ b/src/mpsc/sync.rs
@@ -55,28 +55,44 @@ impl<T: Default> Sender<T> {
     }
 
     pub fn send_ref(&self) -> Result<SendRef<'_, T>, Closed> {
-        let mut waiter = queue::Waiter::new();
-        loop {
-            // perform one send ref loop iteration
+        // fast path: avoid getting the thread and constructing the node if the
+        // slot is immediately ready.
+        match self.inner.try_send_ref() {
+            Ok(slot) => return Ok(SendRef(slot)),
+            Err(TrySendError::Closed(_)) => return Err(Closed(())),
+            _ => {}
+        }
 
-            let waiter = unsafe {
+        let mut waiter = queue::Waiter::new();
+        let mut has_queued = false;
+        let thread = thread::current();
+        loop {
+            let node = unsafe {
                 // Safety: in this case, it's totally safe to pin the waiter, as
                 // it is owned uniquely by this function, and it cannot possibly
                 // be moved while this thread is parked.
                 Pin::new_unchecked(&mut waiter)
             };
-            if let Poll::Ready(result) = self.inner.poll_send_ref(waiter, |thread| {
-                if thread.is_none() {
-                    let current = thread::current();
-                    test_println!("registering {:?}", current);
-                    *thread = Some(current);
-                }
-            }) {
-                return result.map(SendRef);
-            }
 
-            // if that iteration failed, park the thread.
-            thread::park();
+            let wait = if has_queued {
+                // spurious wakeup?
+                test_dbg!(self.inner.tx_wait.continue_wait(node, &thread))
+            } else {
+                has_queued = true;
+                test_dbg!(self.inner.tx_wait.start_wait(node, &thread))
+            };
+
+            match wait {
+                WaitResult::Closed => return Err(Closed(())),
+                WaitResult::Notified => match self.inner.try_send_ref() {
+                    Ok(slot) => return Ok(SendRef(slot)),
+                    Err(TrySendError::Closed(_)) => return Err(Closed(())),
+                    _ => {}
+                },
+                WaitResult::Wait => {
+                    thread::park();
+                }
+            }
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -28,7 +28,7 @@ impl Backoff {
         Self(0)
     }
 
-    #[inline]
+    #[inline(always)]
     pub(crate) fn spin(&mut self) {
         #[cfg(not(all(loom, test)))]
         for _ in 0..test_dbg!(1 << self.0.min(Self::MAX_SPINS)) {
@@ -46,7 +46,7 @@ impl Backoff {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub(crate) fn spin_yield(&mut self) {
         if self.0 <= Self::MAX_SPINS || cfg!(not(any(feature = "std", test))) {
             #[cfg(not(all(loom, test)))]

--- a/src/util/mutex.rs
+++ b/src/util/mutex.rs
@@ -1,5 +1,5 @@
 feature! {
-    #![feature = "std"]
+    #![all(feature = "std", not(feature = "parking_lot"))]
     pub(crate) use self::std_impl::*;
     mod std_impl;
 }
@@ -9,3 +9,9 @@ pub(crate) use self::spin_impl::*;
 
 #[cfg(any(not(feature = "std"), test))]
 mod spin_impl;
+
+feature! {
+    #![all(feature = "std", feature = "parking_lot")]
+    #[allow(unused_imports)]
+    pub(crate) use parking_lot::{Mutex, MutexGuard};
+}

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -54,21 +54,35 @@ pub(crate) enum WaitResult {
     Notified,
 }
 
-pub(crate) trait Notify: UnwindSafe + fmt::Debug {
+pub(crate) trait Notify: UnwindSafe + fmt::Debug + Clone {
     fn notify(self);
+
+    fn same(&self, other: &Self) -> bool;
 }
 
 #[cfg(feature = "std")]
 impl Notify for thread::Thread {
+    #[inline]
     fn notify(self) {
         test_println!("NOTIFYING {:?} (from {:?})", self, thread::current());
         self.unpark();
     }
+
+    #[inline]
+    fn same(&self, other: &Self) -> bool {
+        other.id() == self.id()
+    }
 }
 
 impl Notify for Waker {
+    #[inline]
     fn notify(self) {
         test_println!("WAKING TASK {:?} (from {:?})", self, thread::current());
         self.wake();
+    }
+
+    #[inline]
+    fn same(&self, other: &Self) -> bool {
+        other.will_wake(self)
     }
 }

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -118,10 +118,10 @@ struct List<T> {
     tail: Link<Waiter<T>>,
 }
 
-const EMPTY: usize = 0b00;
-const WAITING: usize = 0b1;
-const WAKING: usize = 0b10;
-const CLOSED: usize = 0b100;
+const EMPTY: usize = 0;
+const WAITING: usize = 1;
+const WAKING: usize = 2;
+const CLOSED: usize = 3;
 
 impl<T: Notify + Unpin> WaitQueue<T> {
     pub(crate) fn new() -> Self {
@@ -385,7 +385,8 @@ impl<T: Notify + Unpin> WaitQueue<T> {
     /// Close the queue, notifying all waiting tasks.
     pub(crate) fn close(&self) {
         test_println!("WaitQueue::close()");
-        test_dbg!(self.state.store(CLOSED, Release));
+
+        test_dbg!(self.state.store(CLOSED, SeqCst));
         let mut list = self.list.lock();
         while !list.is_empty() {
             if let Some(waiter) = list.dequeue(WaiterState::Closed) {

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -1,6 +1,6 @@
 use crate::{
     loom::{
-        atomic::{AtomicBool, AtomicUsize, Ordering::*},
+        atomic::{AtomicUsize, Ordering::*},
         cell::UnsafeCell,
     },
     util::{mutex::Mutex, CachePadded},

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -204,7 +204,8 @@ impl<T: Notify + Unpin> WaitQueue<T> {
                         _state,
                         State::Waiting,
                         "start_wait_slow: unexpected state value! this is a bug!",
-                    )
+                    );
+                    break;
                 }
             }
         }

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -396,6 +396,7 @@ impl<T> Waiter<T> {
     /// # Safety
     ///
     /// This is only safe to call while the list is locked.
+    #[inline(always)]
     unsafe fn with_node<U>(&self, f: impl FnOnce(&mut Node<T>) -> U) -> U {
         self.node.with_mut(|node| f(&mut *node))
     }

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -608,7 +608,7 @@ impl<T> fmt::Debug for List<T> {
         f.debug_struct("List")
             .field("head", &self.head)
             .field("tail", &self.tail)
-            .field("is_emtpy", &self.is_empty())
+            .field("is_empty", &self.is_empty())
             .finish()
     }
 }

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -381,12 +381,12 @@ impl<T: Notify> Waiter<T> {
         self.with_node(|node| node.waiter.take())
     }
 
-    #[inline(never)]
+    #[inline(always)]
     fn swap_state(&self, new_state: WaiterState) -> WaiterState {
         self.state.swap(new_state as u8, AcqRel).into()
     }
 
-    #[inline(never)]
+    #[inline(always)]
     fn state(&self) -> WaiterState {
         self.state.load(Acquire).into()
     }

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -265,9 +265,12 @@ impl<T: Notify + Unpin> WaitQueue<T> {
         });
 
         let _prev_state = test_dbg!(node.state.swap(WAITING, Release));
-        debug_assert_eq!(
-            _prev_state, EMPTY,
-            "start_wait_slow: called with a node that was not in the empty state!"
+        debug_assert!(
+            _prev_state == EMPTY || _prev_state == WAKING,
+            "start_wait_slow: called with a node that was not empty ({}) or woken ({})! actual={}",
+            EMPTY,
+            WAKING,
+            _prev_state,
         );
         list.enqueue(node);
 

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -128,7 +128,7 @@ impl<T: Notify + Unpin> WaitQueue<T> {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub(crate) fn start_wait(
         &self,
         waiter: Pin<&mut Waiter<T>>,
@@ -145,6 +145,7 @@ impl<T: Notify + Unpin> WaitQueue<T> {
         self.start_wait_slow(waiter, mk_waiter)
     }
 
+    #[cold]
     #[inline(never)]
     fn start_wait_slow(
         &self,
@@ -243,7 +244,7 @@ impl<T: Notify + Unpin> WaitQueue<T> {
     ///
     /// If a waiter was popped from the queue, returns `true`. Otherwise, if the
     /// notification was assigned to the queue, returns `false`.
-    #[inline]
+    #[inline(always)]
     pub(crate) fn notify(&self) -> bool {
         test_println!("WaitQueue::notify()");
         let mut state = test_dbg!(self.state.load(SeqCst));
@@ -264,6 +265,7 @@ impl<T: Notify + Unpin> WaitQueue<T> {
     }
 
     #[cold]
+    #[inline(always)]
     fn notify_slow(&self, state: usize) -> bool {
         let mut list = self.list.lock();
         match state {

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -85,8 +85,8 @@ pub(crate) struct WaitQueue<T> {
 /// A waiter node which may be linked into a wait queue.
 #[derive(Debug)]
 pub(crate) struct Waiter<T> {
+    state: CachePadded<AtomicUsize>,
     node: UnsafeCell<Node<T>>,
-    state: AtomicUsize,
 }
 
 #[derive(Debug)]
@@ -393,13 +393,13 @@ impl<T: Notify + Unpin> WaitQueue<T> {
 impl<T: Notify> Waiter<T> {
     pub(crate) fn new() -> Self {
         Self {
+            state: CachePadded(AtomicUsize::new(EMPTY)),
             node: UnsafeCell::new(Node {
                 next: None,
                 prev: None,
                 waiter: None,
                 _pin: PhantomPinned,
             }),
-            state: AtomicUsize::new(EMPTY),
         }
     }
 

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -128,7 +128,6 @@ impl<T: Notify + Unpin> WaitQueue<T> {
         }
     }
 
-    #[inline(always)]
     pub(crate) fn start_wait(&self, node: Pin<&mut Waiter<T>>, waiter: &T) -> WaitResult {
         test_println!("WaitQueue::start_wait");
         // optimistically, acquire a stored notification before trying to lock.
@@ -141,8 +140,6 @@ impl<T: Notify + Unpin> WaitQueue<T> {
         self.start_wait_slow(node, waiter)
     }
 
-    #[cold]
-    #[inline(never)]
     fn start_wait_slow(&self, node: Pin<&mut Waiter<T>>, waiter: &T) -> WaitResult {
         test_println!("WaitQueue::start_wait_slow");
         // There are no queued notifications to consume, and the queue is
@@ -234,7 +231,7 @@ impl<T: Notify + Unpin> WaitQueue<T> {
     ///
     /// If a waiter was popped from the queue, returns `true`. Otherwise, if the
     /// notification was assigned to the queue, returns `false`.
-    #[inline(always)]
+    // #[inline(always)]
     pub(crate) fn notify(&self) -> bool {
         test_println!("WaitQueue::notify()");
         let mut state = test_dbg!(self.state.load(SeqCst));
@@ -254,8 +251,8 @@ impl<T: Notify + Unpin> WaitQueue<T> {
         self.notify_slow(state)
     }
 
-    #[cold]
-    #[inline(always)]
+    // #[cold]
+    // #[inline(always)]
     fn notify_slow(&self, state: usize) -> bool {
         let mut list = self.list.lock();
         match state {

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -367,7 +367,7 @@ impl<T: Notify> Waiter<T> {
 
     #[inline]
     pub(crate) fn is_linked(&self) -> bool {
-        test_dbg!(self.state.load(Acquire)) != WaiterState::Waiting as u8
+        test_dbg!(self.state()) == WaiterState::Waiting
     }
 
     /// # Safety

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -348,6 +348,7 @@ impl<T: Notify> Waiter<T> {
         }
     }
 
+    #[inline(never)]
     pub(crate) fn remove(self: Pin<&mut Self>, q: &WaitQueue<T>) {
         test_println!("Waiter::remove({:p})", self);
         unsafe {
@@ -364,6 +365,7 @@ impl<T: Notify> Waiter<T> {
         }
     }
 
+    #[inline]
     pub(crate) fn is_linked(&self) -> bool {
         test_dbg!(self.state.load(Acquire)) != WaiterState::Waiting as u8
     }
@@ -371,6 +373,7 @@ impl<T: Notify> Waiter<T> {
     /// # Safety
     ///
     /// This is only safe to call while the list is locked.
+    #[inline]
     unsafe fn take_waker(self: Pin<&mut Self>, new_state: WaiterState) -> Option<T> {
         test_println!("Waiter::take_waker({:p}, {:?})", self, new_state);
         let _prev_state = test_dbg!(self.swap_state(new_state));
@@ -378,10 +381,12 @@ impl<T: Notify> Waiter<T> {
         self.with_node(|node| node.waiter.take())
     }
 
+    #[inline(never)]
     fn swap_state(&self, new_state: WaiterState) -> WaiterState {
         self.state.swap(new_state as u8, AcqRel).into()
     }
 
+    #[inline(never)]
     fn state(&self) -> WaiterState {
         self.state.load(Acquire).into()
     }

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -147,13 +147,7 @@ impl<T: Notify + Unpin> WaitQueue<T> {
         match test_dbg!(self.state.compare_exchange(WAKING, EMPTY, SeqCst, SeqCst)) {
             Ok(_) => return WaitResult::Notified,
             Err(CLOSED) => return WaitResult::Closed,
-            Err(_state) => {
-                debug_assert_eq!(
-                    _state, WAITING,
-                    "start_wait: unexpected wait queue state {:?} (expected WAITING). this is a bug!",
-                    _state,
-                );
-            }
+            Err(_) => {}
         }
 
         // Slow path: the queue is not closed, and we failed to consume a stored


### PR DESCRIPTION
This branch rewrites the MPSC channel wait queue implementation (again),
in order to improve performance. This undoes a decently large amount of
the perf regression from PR #20.

In particular, I've made the following changes:
* Simplified the design a bit, and reduced the number of CAS loops in
  both the notify and wait paths
* Factored out fast paths (which touch the state variable without
  locking) from the notify and wait operations into separate functions,
  and marked them as `#[inline(always)]`. If we weren't able to perform
  the operation without actually touching the linked list, we call into
  a separate `#[inline(never)]` function that actually locks the list
  and performs the slow path. This means that code that uses these
  functions still has a function call in it, but a few instructions for
  performing a CAS can be inlined and the function call avoided in some
  cases. This *significantly* improves performance!
* Separated the `wait` function into `start_wait` (called the first time
  a node waits) and `continue_wait` (called if the node is woken, to
  handle spurious wakeups). This allows simplifying the code for
  modifying the waker so that we don't have to pass big closures around.
* Other miscellaneous optimizations, such as cache padding some
  variables that should have been cache padded.

## Performance Comparison

These benchmarks were run against the current `main` branch
(f77d53475ca16c5a18cc6e4138f96f449064b004).

### async/mpsc_reusable

```
async/mpsc_reusable/ThingBuf/10
                        time:   [43.953 us 44.522 us 45.057 us]
                        change: [+0.0419% +1.7594% +3.5099%] (p = 0.05 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
async/mpsc_reusable/ThingBuf/50
                        time:   [140.91 us 142.24 us 143.53 us]
                        change: [-31.201% -29.539% -27.824%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
async/mpsc_reusable/ThingBuf/100
                        time:   [250.31 us 255.03 us 259.68 us]
                        change: [-18.966% -17.190% -15.202%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

```

### async/mpsc_integer

```
async/mpsc_integer/ThingBuf/10
                        time:   [208.99 us 215.30 us 221.32 us]
                        change: [+0.6957% +3.8603% +6.9400%] (p = 0.02 < 0.05)
                        Change within noise threshold.
async/mpsc_integer/ThingBuf/50
                        time:   [407.46 us 412.74 us 418.31 us]
                        change: [-39.128% -36.567% -33.267%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  7 (7.00%) high severe
async/mpsc_integer/ThingBuf/100
                        time:   [534.35 us 541.42 us 548.91 us]
                        change: [-44.820% -41.502% -37.120%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  7 (7.00%) high severe
```

### async/spsc/try_send_reusable

```
async/spsc/try_send_reusable/ThingBuf/100
                        time:   [12.310 us 12.353 us 12.398 us]
                        thrpt:  [8.0656 Melem/s 8.0952 Melem/s 8.1236 Melem/s]
                 change:
                        time:   [-7.5146% -7.1996% -6.8566%] (p = 0.00 < 0.05)
                        thrpt:  [+7.3613% +7.7582% +8.1252%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
async/spsc/try_send_reusable/ThingBuf/500
                        time:   [46.691 us 46.778 us 46.871 us]
                        thrpt:  [10.668 Melem/s 10.689 Melem/s 10.709 Melem/s]
                 change:
                        time:   [-9.4767% -9.2760% -9.0811%] (p = 0.00 < 0.05)
                        thrpt:  [+9.9881% +10.224% +10.469%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
async/spsc/try_send_reusable/ThingBuf/1000
                        time:   [89.763 us 90.757 us 91.843 us]
                        thrpt:  [10.888 Melem/s 11.018 Melem/s 11.140 Melem/s]
                 change:
                        time:   [-9.4302% -8.8637% -8.2018%] (p = 0.00 < 0.05)
                        thrpt:  [+8.9346% +9.7257% +10.412%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  8 (8.00%) high severe
async/spsc/try_send_reusable/ThingBuf/5000
                        time:   [415.34 us 417.89 us 420.42 us]
                        thrpt:  [11.893 Melem/s 11.965 Melem/s 12.038 Melem/s]
                 change:
                        time:   [-13.113% -12.774% -12.411%] (p = 0.00 < 0.05)
                        thrpt:  [+14.170% +14.644% +15.093%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild
async/spsc/try_send_reusable/ThingBuf/10000
                        time:   [847.35 us 848.63 us 849.98 us]
                        thrpt:  [11.765 Melem/s 11.784 Melem/s 11.802 Melem/s]
                 change:
                        time:   [-11.345% -10.820% -10.388%] (p = 0.00 < 0.05)
                        thrpt:  [+11.592% +12.133% +12.796%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
```

### async/spsc/try_send_integer

```
async/spsc/try_send_integer/ThingBuf/100
                        time:   [7.2254 us 7.2467 us 7.2690 us]
                        thrpt:  [13.757 Melem/s 13.799 Melem/s 13.840 Melem/s]
                 change:
                        time:   [-13.292% -12.912% -12.520%] (p = 0.00 < 0.05)
                        thrpt:  [+14.312% +14.826% +15.330%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
async/spsc/try_send_integer/ThingBuf/500
                        time:   [34.358 us 34.477 us 34.582 us]
                        thrpt:  [14.458 Melem/s 14.503 Melem/s 14.553 Melem/s]
                 change:
                        time:   [-18.539% -18.312% -18.072%] (p = 0.00 < 0.05)
                        thrpt:  [+22.058% +22.417% +22.758%]
                        Performance has improved.
async/spsc/try_send_integer/ThingBuf/1000
                        time:   [69.107 us 69.273 us 69.434 us]
                        thrpt:  [14.402 Melem/s 14.436 Melem/s 14.470 Melem/s]
                 change:
                        time:   [-17.759% -17.604% -17.444%] (p = 0.00 < 0.05)
                        thrpt:  [+21.130% +21.365% +21.594%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
async/spsc/try_send_integer/ThingBuf/5000
                        time:   [349.44 us 353.41 us 357.81 us]
                        thrpt:  [13.974 Melem/s 14.148 Melem/s 14.309 Melem/s]
                 change:
                        time:   [-14.832% -14.252% -13.447%] (p = 0.00 < 0.05)
                        thrpt:  [+15.537% +16.621% +17.415%]
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe
async/spsc/try_send_integer/ThingBuf/10000
                        time:   [712.89 us 732.58 us 754.24 us]
                        thrpt:  [13.258 Melem/s 13.650 Melem/s 14.027 Melem/s]
                 change:
                        time:   [-16.082% -15.161% -14.129%] (p = 0.00 < 0.05)
                        thrpt:  [+16.454% +17.870% +19.164%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
```

I'm actually not really sure why this also improved the `try_send`
benchmarks, which don't touch the wait queue...but I'll take it!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>