### PR TITLE
refac: remove special empty state from slots

### DIFF
--- a/src/static_thingbuf.rs
+++ b/src/static_thingbuf.rs
@@ -11,12 +11,10 @@ pub struct StaticThingBuf<T, const CAP: usize> {
 
 #[cfg(not(test))]
 impl<T, const CAP: usize> StaticThingBuf<T, CAP> {
-    const SLOT: Slot<T> = Slot::empty();
-
     pub const fn new() -> Self {
         Self {
             core: Core::new(CAP),
-            slots: [Self::SLOT; CAP],
+            slots: Slot::make_static_array::<CAP>(),
         }
     }
 }

--- a/src/thingbuf.rs
+++ b/src/thingbuf.rs
@@ -17,10 +17,9 @@ pub struct ThingBuf<T> {
 impl<T: Default> ThingBuf<T> {
     pub fn new(capacity: usize) -> Self {
         assert!(capacity > 0);
-        let slots = (0..capacity).map(|_| Slot::empty()).collect();
         Self {
             core: Core::new(capacity),
-            slots,
+            slots: Slot::make_boxed_array(capacity),
         }
     }
 


### PR DESCRIPTION
This isn't necessary, as we can use a const while loop
to fill in the slots with correct indices.

This makes the push and pop code a little simpler, which
may also improve performance!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>