### PR TITLE
fix(mpsc): ensure un-received messages are dropped

### DIFF
--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -55,6 +55,42 @@ jobs:
           command: test
           args: --profile loom --lib -- mpsc_try_send_recv
 
+  async_rx_close_unconsumed:
+    name: "mpsc::rx_close_unconsumed"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --profile loom --lib -- mpsc::rx_close_unconsumed
+
+  sync_rx_close_unconsumed:
+    name: "sync::rx_close_unconsumed"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --profile loom --lib -- mpsc_sync::rx_close_unconsumed
+
   loom_mpsc_async:
     name: "mpsc"
     runs-on: ubuntu-latest

--- a/src/mpsc/async_impl.rs
+++ b/src/mpsc/async_impl.rs
@@ -595,16 +595,25 @@ impl<T> PinnedDrop for SendRefFuture<'_, T> {
     }
 }
 
-#[cfg(feature = "alloc")]
-impl<T> fmt::Debug for Inner<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Inner")
-            .field("core", &self.core)
-            .field("slots", &format_args!("Box<[..]>"))
-            .finish()
+feature! {
+    #![feature = "alloc"]
+    impl<T> fmt::Debug for Inner<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("Inner")
+                .field("core", &self.core)
+                .field("slots", &format_args!("Box<[..]>"))
+                .finish()
+        }
+    }
+
+    impl<T> Drop for Inner<T> {
+        fn drop(&mut self) {
+            self.core.core.drop_slots(&mut self.slots[..])
+        }
     }
 }
 
+#[cfg(feature = "alloc")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/mpsc/sync.rs
+++ b/src/mpsc/sync.rs
@@ -385,6 +385,12 @@ impl<T> fmt::Debug for Inner<T> {
     }
 }
 
+impl<T> Drop for Inner<T> {
+    fn drop(&mut self) {
+        self.core.core.drop_slots(&mut self.slots[..])
+    }
+}
+
 #[inline]
 fn recv_ref<'a, T: Default>(
     core: &'a ChannelCore<Thread>,

--- a/src/mpsc/tests/mpsc_async.rs
+++ b/src/mpsc/tests/mpsc_async.rs
@@ -103,7 +103,6 @@ fn rx_close_unconsumed_spsc() {
         });
 
         consumer.join().unwrap();
-        drop(tx);
     })
 }
 

--- a/src/mpsc/tests/mpsc_async.rs
+++ b/src/mpsc/tests/mpsc_async.rs
@@ -75,8 +75,13 @@ fn rx_closes() {
 }
 
 #[test]
+#[cfg_attr(ci_skip_slow_models, ignore)]
 fn rx_close_unconsumed() {
-    const MESSAGES: usize = 4;
+    // XXX(eliza): it would be nice to run this with more messages, but
+    // increasing this makes the model really unreasonably slow --- on my
+    // machine, four messages takes over 89,000,000 iterations and runs for
+    // about 2 hours...
+    const MESSAGES: usize = 2;
 
     async fn do_producer(tx: Sender<Track<i32>>, n: usize) {
         let mut i = 1;

--- a/src/mpsc/tests/mpsc_sync.rs
+++ b/src/mpsc/tests/mpsc_sync.rs
@@ -79,12 +79,37 @@ fn rx_closes() {
 }
 
 #[test]
-#[cfg_attr(ci_skip_slow_models, ignore)]
-fn rx_close_unconsumed() {
-    // XXX(eliza): it would be nice to run this with more messages, but
-    // increasing this makes the model really unreasonably slow --- on my
-    // machine, four messages takes over 89,000,000 iterations and runs for
-    // about 2 hours...
+fn rx_close_unconsumed_spsc() {
+    // Tests that messages that have not been consumed by the receiver are
+    // dropped when dropping the channel.
+    const MESSAGES: usize = 4;
+
+    loom::model(|| {
+        let (tx, rx) = sync::channel(MESSAGES);
+
+        let consumer = thread::spawn(move || {
+            // recieve one message
+            let msg = rx.recv();
+            test_println!("recv {:?}", msg);
+            assert!(msg.is_some());
+            // drop the receiver...
+        });
+
+        let mut i = 1;
+        while let Ok(mut slot) = tx.send_ref() {
+            test_println!("producer sending {}...", i);
+            *slot = Track::new(i);
+            i += 1;
+        }
+
+        consumer.join().unwrap();
+        drop(tx);
+    })
+}
+
+#[test]
+#[ignore] // This is marked as `ignore` because it takes over an hour to run.
+fn rx_close_unconsumed_mpsc() {
     const MESSAGES: usize = 2;
 
     fn do_producer(tx: sync::Sender<Track<i32>>, n: usize) -> impl FnOnce() + Send + Sync {

--- a/src/mpsc/tests/mpsc_sync.rs
+++ b/src/mpsc/tests/mpsc_sync.rs
@@ -79,8 +79,13 @@ fn rx_closes() {
 }
 
 #[test]
+#[cfg_attr(ci_skip_slow_models, ignore)]
 fn rx_close_unconsumed() {
-    const MESSAGES: usize = 4;
+    // XXX(eliza): it would be nice to run this with more messages, but
+    // increasing this makes the model really unreasonably slow --- on my
+    // machine, four messages takes over 89,000,000 iterations and runs for
+    // about 2 hours...
+    const MESSAGES: usize = 2;
 
     fn do_producer(tx: sync::Sender<Track<i32>>, n: usize) -> impl FnOnce() + Send + Sync {
         move || {

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -437,7 +437,7 @@ impl<T: Notify + Unpin> WaitQueue<T> {
     pub(crate) fn close(&self) {
         test_println!("WaitQueue::close()");
 
-        test_dbg!(self.state.store(CLOSED, SeqCst));
+        test_dbg!(self.state.swap(CLOSED, SeqCst));
         let mut list = self.list.lock();
         while !list.is_empty() {
             if let Some(waiter) = list.dequeue(CLOSED) {


### PR DESCRIPTION
This also adds loom leak checking tests. 

I also made `WaitQueue::close` into an RMW op to work around `loom`
not modeling `SeqCst` properly.