### PR TITLE
test: add Miri tests, fix a stacked borrows violation

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.rs'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**.rs'
+
+name: Miri
+jobs:
+  tests:
+    name: Miri tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: miri
+      - name: Run Miri tests
+      - name: miri
+        run: cargo miri test --lib --no-fail-fast
+        env:
+          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-tag-raw-pointers

--- a/bin/miri
+++ b/bin/miri
@@ -7,4 +7,4 @@ set -x
 cd "$(dirname "$0")"/..
 
 MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tag-raw-pointers ${MIRIFLAGS:-}" \
-    cargo +nightly miri test --lib
+    cargo +nightly miri test --lib "${@}"

--- a/bin/miri
+++ b/bin/miri
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Runs `miri` tests
+set -euo pipefail
+set -x
+
+cd "$(dirname "$0")"/..
+
+MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tag-raw-pointers ${MIRIFLAGS:-}" \
+    cargo +nightly miri test --lib

--- a/src/mpsc/tests/mpsc_async.rs
+++ b/src/mpsc/tests/mpsc_async.rs
@@ -1,7 +1,5 @@
 use super::*;
-use crate::{
-    loom::{self, alloc::Track, future, thread},
-};
+use crate::loom::{self, alloc::Track, future, thread};
 
 #[test]
 #[cfg_attr(ci_skip_slow_models, ignore)]

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -226,7 +226,7 @@ impl<T: Notify + Unpin> WaitQueue<T> {
                     {
                         Ok(_) => break,
                         Err(actual) => {
-                            debug_assert!(actual == WAKING || actual == CLOSED);
+                            debug_assert!(actual == EMPTY || actual == WAKING || actual == CLOSED);
                             state = actual;
                         }
                     }
@@ -242,7 +242,7 @@ impl<T: Notify + Unpin> WaitQueue<T> {
                         // Consumed the wakeup!
                         Ok(_) => return WaitResult::Notified,
                         Err(actual) => {
-                            debug_assert!(actual == EMPTY || actual == CLOSED);
+                            debug_assert!(actual == WAKING || actual == EMPTY || actual == CLOSED);
                             state = actual;
                         }
                     }


### PR DESCRIPTION
This branch adds support for running Miri tests against `thingbuf`. The
primary reason to use Miri is for testing the wait queue linked list
implementation. Other unsafe code in `thingbuf` is primarily unsafe due
to potential concurrent access issues (which are tested for using
`loom`), rather than doing anything particularly weird with raw pointers
and lifetimes (for which we would want to use Miri).

In order to actually test the implementation using Miri, I wrote a few
tests that exercise basic functionality for the wait queue. 

In the process, I fixed two issues:
- A potential stacked borrows violation in the `enqueue` operation due
to creating a raw pointer to the node being enqueued while there is also
an `&mut` reference to it. This code doesn't currently result in
anything bad happening, as the `&mut` ref doesn't outlive the stack
frame in which the raw ptr is created, but it's a stacked borrows
violation and is technically unsound. This was solved by re-ordering
some of the code so that the raw pointer to the node being enqueued is
not created until we are finished mutating it through the mut ref. 
- Some debug assertions didn't take into account the potential for
`compare_exchange_weak` to fail spuriously with the expected value, and
asserted it was not that value. Apparently miri causes spurious
`compare_exchange_weak` failures (which was surprising to me) and
triggered those assertions. I'm surprised they weren't also triggered
under loom!

There's now a bash script for running Miri locally, and I've added a CI
job to run Miri tests.