### PR TITLE
chore(ci): trigger CI runs when test files change

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -4,10 +4,12 @@ on:
       - main
     paths:
       - '**.rs'
+      - '.github/workflows/lints.yml'
   workflow_dispatch:
   pull_request:
     paths:
       - '**.rs'
+      - '.github/workflows/lints.yml'
 
 name: Lints
 jobs:

--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -5,11 +5,13 @@ on:
     paths:
       - '**.rs'
       - '**/Cargo.toml'
+      - '.github/workflows/loom.yml'
   workflow_dispatch:
   pull_request:
     paths:
       - '**.rs'
       - '**/Cargo.toml'
+      - '.github/workflows/loom.yml'
 
 name: Loom Models
 

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -4,10 +4,12 @@ on:
       - main
     paths:
       - '**.rs'
+      - '.github/workflows/miri.yml'
   workflow_dispatch:
   pull_request:
     paths:
       - '**.rs'
+      - '.github/workflows/miri.yml'
 
 name: Miri
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,17 +5,19 @@ on:
     paths:
       - '**.rs'
       - '**/Cargo.toml'
+      - '.github/workflows/tests.yml'
   workflow_dispatch:
   pull_request:
     paths:
       - '**.rs'
       - '**/Cargo.toml'
+      - '.github/workflows/tests.yml'
 
 name: Tests
 jobs:
 
   tests:
-    name: Integration tests
+    name: Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Currently, CI jobs are not triggered when changing their configuration
files. This is not great --- when we change the CI configs, we should
ensure that the CI jobs actually run.

This branch fixes that by adding the CI jobs' config files to the files
that trigger runs when modified.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>