### PR TITLE
chore: rename `mpsc::sync` to `mpsc::blocking`

### DIFF
--- a/bench/benches/sync_spsc.rs
+++ b/bench/benches/sync_spsc.rs
@@ -20,8 +20,8 @@ aaaaaaaaaaaaaa";
         group.throughput(Throughput::Elements(size));
         group.bench_with_input(BenchmarkId::new("ThingBuf", size), &size, |b, &i| {
             b.iter(|| {
-                use thingbuf::mpsc::{sync, TrySendError};
-                let (tx, rx) = sync::channel::<String>(100);
+                use thingbuf::mpsc::{blocking, TrySendError};
+                let (tx, rx) = blocking::channel::<String>(100);
                 let producer = thread::spawn(move || loop {
                     match tx.try_send_ref() {
                         Ok(mut slot) => {
@@ -103,8 +103,8 @@ aaaaaaaaaaaaaa";
         group.throughput(Throughput::Elements(size));
         group.bench_with_input(BenchmarkId::new("ThingBuf", size), &size, |b, &i| {
             b.iter(|| {
-                use thingbuf::mpsc::sync;
-                let (tx, rx) = sync::channel::<String>(100);
+                use thingbuf::mpsc::blocking;
+                let (tx, rx) = blocking::channel::<String>(100);
                 let producer = thread::spawn(move || {
                     while let Ok(mut slot) = tx.send_ref() {
                         slot.clear();

--- a/src/mpsc.rs
+++ b/src/mpsc.rs
@@ -5,10 +5,10 @@
 //! receiving task willwait when there are no messages in the channel.
 //!
 //! If the "std" feature flag is enabled, this module also provides a
-//! synchronous channel, in the [`sync`] module. The synchronous  receiver will
-//! instead wait for new messages by blocking the current thread. Naturally,
-//! this requires the Rust standard library. A synchronous channel
-//! can be constructed using the [`sync::channel`] function.
+//! synchronous channel, in the [`blocking`] module. The synchronous receiver
+//! will instead wait for new messages by blocking the current thread.
+//! Naturally, this requires the Rust standard library. A synchronous channel
+//! can be constructed using the [`blocking::channel`] function.
 
 use crate::{
     loom::{atomic::AtomicUsize, hint},
@@ -405,7 +405,7 @@ pub use self::async_impl::*;
 
 feature! {
     #![feature = "std"]
-    pub mod sync;
+    pub mod blocking;
 }
 
 #[cfg(all(loom, test))]

--- a/src/mpsc/blocking.rs
+++ b/src/mpsc/blocking.rs
@@ -666,7 +666,7 @@ where
     /// use thingbuf::mpsc::blocking;
     /// use std::{fmt::Write, thread};
     ///
-    /// let (tx, rx) = sync::channel::<String>(8);
+    /// let (tx, rx) = blocking::channel::<String>(8);
     ///
     /// // Spawn a thread that prints each message received from the channel:
     /// thread::spawn(move || {
@@ -721,7 +721,7 @@ where
     /// use thingbuf::mpsc::blocking;
     /// use std::thread;
     ///
-    /// let (tx, rx) = sync::channel(8);
+    /// let (tx, rx) = blocking::channel(8);
     ///
     /// // Spawn a thread that prints each message received from the channel:
     /// thread::spawn(move || {
@@ -866,7 +866,7 @@ impl<T, R> Receiver<T, R> {
     /// use thingbuf::mpsc::blocking;
     /// use std::{thread, fmt::Write};
     ///
-    /// let (tx, rx) = sync::channel::<String>(100);
+    /// let (tx, rx) = blocking::channel::<String>(100);
     ///
     /// thread::spawn(move || {
     ///     let mut value = tx.send_ref().unwrap();
@@ -884,7 +884,7 @@ impl<T, R> Receiver<T, R> {
     /// use thingbuf::mpsc::blocking;
     /// use std::fmt::Write;
     ///
-    /// let (tx, rx) = sync::channel::<String>(100);
+    /// let (tx, rx) = blocking::channel::<String>(100);
     ///
     /// write!(tx.send_ref().unwrap(), "hello").unwrap();
     /// write!(tx.send_ref().unwrap(), "world").unwrap();
@@ -923,7 +923,7 @@ impl<T, R> Receiver<T, R> {
     /// use thingbuf::mpsc::blocking;
     /// use std::{thread, fmt::Write};
     ///
-    /// let (tx, rx) = sync::channel(100);
+    /// let (tx, rx) = blocking::channel(100);
     ///
     /// thread::spawn(move || {
     ///    tx.send(1).unwrap();
@@ -938,7 +938,7 @@ impl<T, R> Receiver<T, R> {
     /// ```
     /// use thingbuf::mpsc::blocking;
     ///
-    /// let (tx, rx) = sync::channel(100);
+    /// let (tx, rx) = blocking::channel(100);
     ///
     /// tx.send(1).unwrap();
     /// tx.send(2).unwrap();

--- a/src/mpsc/blocking.rs
+++ b/src/mpsc/blocking.rs
@@ -97,7 +97,7 @@ feature! {
     /// # Examples
     ///
     /// ```
-    /// use thingbuf::mpsc::sync::StaticChannel;
+    /// use thingbuf::mpsc::blocking::StaticChannel;
     ///
     /// // Construct a statically-allocated channel of `usize`s with a capacity
     /// // of 16 messages.
@@ -260,7 +260,7 @@ feature! {
         /// Sending formatted strings by writing them directly to channel slots,
         /// in place:
         /// ```
-        /// use thingbuf::mpsc::sync::StaticChannel;
+        /// use thingbuf::mpsc::blocking::StaticChannel;
         /// use std::{fmt::Write, thread};
         ///
         /// static CHANNEL: StaticChannel<String, 8> = StaticChannel::new();
@@ -313,7 +313,7 @@ feature! {
         /// # Examples
         ///
         /// ```
-        /// use thingbuf::mpsc::sync::StaticChannel;
+        /// use thingbuf::mpsc::blocking::StaticChannel;
         /// use std::{fmt::Write, thread};
         ///
         /// static CHANNEL: StaticChannel<i32, 8> = StaticChannel::new();
@@ -468,7 +468,7 @@ feature! {
         /// # Examples
         ///
         /// ```
-        /// use thingbuf::mpsc::sync::StaticChannel;
+        /// use thingbuf::mpsc::blocking::StaticChannel;
         /// use std::{thread, fmt::Write};
         ///
         /// static CHANNEL: StaticChannel<String, 100> = StaticChannel::new();
@@ -487,7 +487,7 @@ feature! {
         /// Values are buffered:
         ///
         /// ```
-        /// use thingbuf::mpsc::sync::StaticChannel;
+        /// use thingbuf::mpsc::blocking::StaticChannel;
         /// use std::fmt::Write;
         ///
         /// static CHANNEL: StaticChannel<String, 100> = StaticChannel::new();
@@ -527,7 +527,7 @@ feature! {
         /// # Examples
         ///
         /// ```
-        /// use thingbuf::mpsc::sync::StaticChannel;
+        /// use thingbuf::mpsc::blocking::StaticChannel;
         /// use std::thread;
         ///
         /// static CHANNEL: StaticChannel<i32, 100> = StaticChannel::new();
@@ -544,7 +544,7 @@ feature! {
         /// Values are buffered:
         ///
         /// ```
-        /// use thingbuf::mpsc::sync::StaticChannel;
+        /// use thingbuf::mpsc::blocking::StaticChannel;
         ///
         /// static CHANNEL: StaticChannel<i32, 100> = StaticChannel::new();
         /// let (tx, rx) = CHANNEL.split();
@@ -663,7 +663,7 @@ where
     /// Sending formatted strings by writing them directly to channel slots,
     /// in place:
     /// ```
-    /// use thingbuf::mpsc::sync;
+    /// use thingbuf::mpsc::blocking;
     /// use std::{fmt::Write, thread};
     ///
     /// let (tx, rx) = sync::channel::<String>(8);
@@ -718,7 +718,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use thingbuf::mpsc::sync;
+    /// use thingbuf::mpsc::blocking;
     /// use std::thread;
     ///
     /// let (tx, rx) = sync::channel(8);
@@ -863,7 +863,7 @@ impl<T, R> Receiver<T, R> {
     /// # Examples
     ///
     /// ```
-    /// use thingbuf::mpsc::sync;
+    /// use thingbuf::mpsc::blocking;
     /// use std::{thread, fmt::Write};
     ///
     /// let (tx, rx) = sync::channel::<String>(100);
@@ -881,7 +881,7 @@ impl<T, R> Receiver<T, R> {
     /// Values are buffered:
     ///
     /// ```
-    /// use thingbuf::mpsc::sync;
+    /// use thingbuf::mpsc::blocking;
     /// use std::fmt::Write;
     ///
     /// let (tx, rx) = sync::channel::<String>(100);
@@ -920,7 +920,7 @@ impl<T, R> Receiver<T, R> {
     /// # Examples
     ///
     /// ```
-    /// use thingbuf::mpsc::sync;
+    /// use thingbuf::mpsc::blocking;
     /// use std::{thread, fmt::Write};
     ///
     /// let (tx, rx) = sync::channel(100);
@@ -936,7 +936,7 @@ impl<T, R> Receiver<T, R> {
     /// Values are buffered:
     ///
     /// ```
-    /// use thingbuf::mpsc::sync;
+    /// use thingbuf::mpsc::blocking;
     ///
     /// let (tx, rx) = sync::channel(100);
     ///

--- a/src/mpsc/tests.rs
+++ b/src/mpsc/tests.rs
@@ -2,4 +2,4 @@ use super::*;
 
 mod mpsc_async;
 #[cfg(feature = "std")]
-mod mpsc_sync;
+mod mpsc_blocking;

--- a/tests/mpsc_blocking.rs
+++ b/tests/mpsc_blocking.rs
@@ -1,5 +1,5 @@
 use std::thread;
-use thingbuf::mpsc::sync;
+use thingbuf::mpsc::blocking;
 
 #[test]
 fn basically_works() {
@@ -8,7 +8,7 @@ fn basically_works() {
     const N_SENDS: usize = 10;
     const N_PRODUCERS: usize = 10;
 
-    fn start_producer(tx: sync::Sender<usize>, n: usize) -> thread::JoinHandle<()> {
+    fn start_producer(tx: blocking::Sender<usize>, n: usize) -> thread::JoinHandle<()> {
         let tag = n * N_SENDS;
         thread::Builder::new()
             .name(format!("producer {}", n))
@@ -24,7 +24,7 @@ fn basically_works() {
             .expect("spawning threads should succeed")
     }
 
-    let (tx, rx) = sync::channel(N_SENDS / 2);
+    let (tx, rx) = blocking::channel(N_SENDS / 2);
     for n in 0..N_PRODUCERS {
         start_producer(tx.clone(), n);
     }
@@ -56,7 +56,7 @@ fn tx_close_drains_queue() {
     for i in 0..10000 {
         println!("\n\n--- iteration {} ---\n\n", i);
 
-        let (tx, rx) = sync::channel(LEN);
+        let (tx, rx) = blocking::channel(LEN);
         let producer = thread::spawn(move || {
             for i in 0..LEN {
                 tx.send(i).unwrap();

--- a/tests/static_storage.rs
+++ b/tests/static_storage.rs
@@ -145,16 +145,16 @@ async fn static_async_channel() {
 }
 
 #[test]
-fn static_sync_channel() {
+fn static_blocking_channel() {
     use std::collections::HashSet;
-    use thingbuf::mpsc::sync;
+    use thingbuf::mpsc::blocking;
 
     const N_PRODUCERS: usize = 8;
     const N_SENDS: usize = N_PRODUCERS * 2;
 
-    static CHANNEL: sync::StaticChannel<usize, N_PRODUCERS> = sync::StaticChannel::new();
+    static CHANNEL: blocking::StaticChannel<usize, N_PRODUCERS> = blocking::StaticChannel::new();
 
-    fn do_producer(tx: sync::StaticSender<usize>, n: usize) -> impl FnOnce() {
+    fn do_producer(tx: blocking::StaticSender<usize>, n: usize) -> impl FnOnce() {
         move || {
             let tag = n * N_SENDS;
             for i in 0..N_SENDS {


### PR DESCRIPTION
This naming scheme should be a bit less ambiguous.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>