### PR TITLE
feat(mpsc): various error improvements

### DIFF
--- a/bench/benches/async_spsc.rs
+++ b/bench/benches/async_spsc.rs
@@ -22,7 +22,7 @@ aaaaaaaaaaaaaa";
         group.bench_with_input(BenchmarkId::new("ThingBuf", size), &size, |b, &i| {
             let rt = runtime::Builder::new_current_thread().build().unwrap();
             b.to_async(rt).iter(|| async {
-                use thingbuf::mpsc::{self, TrySendError};
+                use thingbuf::mpsc::{self, errors::TrySendError};
 
                 let (tx, rx) = mpsc::channel::<String>(100);
                 task::spawn(async move {
@@ -265,7 +265,7 @@ fn bench_spsc_try_send_integer(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("ThingBuf", size), &size, |b, &i| {
             let rt = runtime::Builder::new_current_thread().build().unwrap();
             b.to_async(rt).iter(|| async {
-                use thingbuf::mpsc::{self, TrySendError};
+                use thingbuf::mpsc::{self, errors::TrySendError};
                 let (tx, rx) = mpsc::channel(100);
                 task::spawn(async move {
                     let mut i = 0;

--- a/bench/benches/sync_spsc.rs
+++ b/bench/benches/sync_spsc.rs
@@ -20,7 +20,7 @@ aaaaaaaaaaaaaa";
         group.throughput(Throughput::Elements(size));
         group.bench_with_input(BenchmarkId::new("ThingBuf", size), &size, |b, &i| {
             b.iter(|| {
-                use thingbuf::mpsc::{blocking, TrySendError};
+                use thingbuf::mpsc::{blocking, errors::TrySendError};
                 let (tx, rx) = blocking::channel::<String>(100);
                 let producer = thread::spawn(move || loop {
                     match tx.try_send_ref() {

--- a/src/mpsc.rs
+++ b/src/mpsc.rs
@@ -20,7 +20,6 @@ use core::{fmt, ops::Index, task::Poll};
 
 /// Error returned by the [`Sender::try_send`] (and [`StaticSender::try_send`])
 /// methods.
-#[derive(Debug)]
 #[non_exhaustive]
 pub enum TrySendError<T = ()> {
     /// The data could not be sent on the channel because the channel is
@@ -33,7 +32,6 @@ pub enum TrySendError<T = ()> {
 
 /// Error returned by [`Sender::send`] and [`Sender::send_ref`], if the
 /// [`Receiver`] half of the channel has been dropped.
-#[derive(Debug)]
 pub struct Closed<T = ()>(T);
 
 #[derive(Debug)]
@@ -67,7 +65,31 @@ struct SendRefInner<'a, T, N: Notify> {
 struct NotifyRx<'a, N: Notify>(&'a WaitCell<N>);
 struct NotifyTx<'a, N: Notify + Unpin>(&'a WaitQueue<N>);
 
-// ==== impl TrySendError ===
+// === impl Closed ===
+
+impl<T> Closed<T> {
+    /// Unwraps the inner `T` value held by this error.
+    ///
+    /// This method allows recovering the original message when sending to a
+    /// channel has failed.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> fmt::Debug for Closed<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Closed(..)")
+    }
+}
+
+impl<T> fmt::Display for Closed<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("channel closed")
+    }
+}
+
+// === impl TrySendError ===
 
 impl TrySendError {
     fn with_value<T>(self, value: T) -> TrySendError<T> {
@@ -78,7 +100,54 @@ impl TrySendError {
     }
 }
 
+impl<T> TrySendError<T> {
+    /// Returns `true` if this error was returned because the channel was at
+    /// capacity.
+    pub fn is_full(&self) -> bool {
+        matches!(self, Self::Full(_))
+    }
+
+    /// Returns `true` if this error was returned because the channel has closed
+    /// (e.g. the `Receiver` end has been dropped).
+    ///
+    /// If this returns `true`, no future `try_send` or `send` operation on this
+    /// channel will succeed.
+    pub fn is_closed(&self) -> bool {
+        matches!(self, Self::Full(_))
+    }
+
+    /// Unwraps the inner `T` value held by this error.
+    ///
+    /// This method allows recovering the original message when sending to a
+    /// channel has failed.
+    pub fn into_inner(self) -> T {
+        match self {
+            Self::Full(val) => val,
+            Self::Closed(val) => val,
+        }
+    }
+}
+
+impl<T> fmt::Debug for TrySendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Full(_) => "TrySendError::Full(..)",
+            Self::Closed(_) => "TrySendError::Closed(..)",
+        })
+    }
+}
+
+impl<T> fmt::Display for TrySendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Full(_) => "no available capacity",
+            Self::Closed(_) => "channel closed",
+        })
+    }
+}
+
 // ==== impl Inner ====
+
 impl<N> ChannelCore<N> {
     #[cfg(not(loom))]
     const fn new(capacity: usize) -> Self {

--- a/src/mpsc.rs
+++ b/src/mpsc.rs
@@ -89,6 +89,9 @@ impl<T> fmt::Display for Closed<T> {
     }
 }
 
+#[cfg(feature = "std")]
+impl<T> std::error::Error for Closed<T> {}
+
 // === impl TrySendError ===
 
 impl TrySendError {
@@ -145,6 +148,9 @@ impl<T> fmt::Display for TrySendError<T> {
         })
     }
 }
+
+#[cfg(feature = "std")]
+impl<T> std::error::Error for TrySendError<T> {}
 
 // ==== impl Inner ====
 

--- a/src/mpsc/async_impl.rs
+++ b/src/mpsc/async_impl.rs
@@ -11,6 +11,7 @@ use core::{
     pin::Pin,
     task::{Context, Poll, Waker},
 };
+use errors::*;
 
 feature! {
     #![feature = "alloc"]

--- a/src/mpsc/blocking.rs
+++ b/src/mpsc/blocking.rs
@@ -16,6 +16,7 @@ use crate::{
     Ref,
 };
 use core::{fmt, pin::Pin};
+use errors::*;
 
 /// Returns a new synchronous multi-producer, single consumer (MPSC)
 /// channel with  the provided capacity.

--- a/src/mpsc/errors.rs
+++ b/src/mpsc/errors.rs
@@ -1,0 +1,124 @@
+//! Errors returned by channels.
+use core::fmt;
+
+/// Error returned by the [`Sender::try_send`] or [`Sender::try_send_ref`] (and
+/// [`StaticSender::try_send`]/[`StaticSender::try_send_ref`]) methods.
+///
+/// [`Sender::try_send`]: super::Sender::try_send
+/// [`Sender::try_send_ref`]: super::Sender::try_send_ref
+/// [`StaticSender::try_send`]: super::StaticSender::try_send
+/// [`StaticSender::try_send_ref`]: super::StaticSender::try_send_ref
+#[non_exhaustive]
+pub enum TrySendError<T = ()> {
+    /// The data could not be sent on the channel because the channel is
+    /// currently full and sending would require waiting for capacity.
+    Full(T),
+    /// The data could not be sent because the [`Receiver`] half of the channel
+    /// has been dropped.
+    ///
+    /// [`Receiver`]: super::Receiver
+    Closed(T),
+}
+
+/// Error returned by [`Sender::send`] or [`Sender::send_ref`] (and
+/// [`StaticSender::send`]/[`StaticSender::send_ref`]), if the
+/// [`Receiver`] half of the channel has been dropped.
+///
+/// [`Sender::send`]: super::Sender::send
+/// [`Sender::send_ref`]: super::Sender::send_ref
+/// [`StaticSender::send`]: super::StaticSender::send
+/// [`StaticSender::send_ref`]: super::StaticSender::send_ref
+/// [`Receiver`]: super::Receiver
+pub struct Closed<T = ()>(pub(crate) T);
+
+// === impl Closed ===
+
+impl<T> Closed<T> {
+    /// Unwraps the inner `T` value held by this error.
+    ///
+    /// This method allows recovering the original message when sending to a
+    /// channel has failed.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> fmt::Debug for Closed<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Closed(..)")
+    }
+}
+
+impl<T> fmt::Display for Closed<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("channel closed")
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T> std::error::Error for Closed<T> {}
+
+// === impl TrySendError ===
+
+impl TrySendError {
+    pub(crate) fn with_value<T>(self, value: T) -> TrySendError<T> {
+        match self {
+            Self::Full(()) => TrySendError::Full(value),
+            Self::Closed(()) => TrySendError::Closed(value),
+        }
+    }
+}
+
+impl<T> TrySendError<T> {
+    /// Returns `true` if this error was returned because the channel was at
+    /// capacity.
+    pub fn is_full(&self) -> bool {
+        matches!(self, Self::Full(_))
+    }
+
+    /// Returns `true` if this error was returned because the channel has closed
+    /// (e.g. the [`Receiver`] end has been dropped).
+    ///
+    /// If this returns `true`, no future [`try_send`] or [`send`] operation on
+    /// this channel will succeed.
+    ///
+    /// [`Receiver`]: super::Receiver
+    /// [`try_send`]: super::Sender::try_send
+    /// [`send`]: super::Sender::send
+    /// [`Receiver`]: super::Receiver
+    pub fn is_closed(&self) -> bool {
+        matches!(self, Self::Full(_))
+    }
+
+    /// Unwraps the inner `T` value held by this error.
+    ///
+    /// This method allows recovering the original message when sending to a
+    /// channel has failed.
+    pub fn into_inner(self) -> T {
+        match self {
+            Self::Full(val) => val,
+            Self::Closed(val) => val,
+        }
+    }
+}
+
+impl<T> fmt::Debug for TrySendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Full(_) => "TrySendError::Full(..)",
+            Self::Closed(_) => "TrySendError::Closed(..)",
+        })
+    }
+}
+
+impl<T> fmt::Display for TrySendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Full(_) => "no available capacity",
+            Self::Closed(_) => "channel closed",
+        })
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T> std::error::Error for TrySendError<T> {}

--- a/src/static_thingbuf.rs
+++ b/src/static_thingbuf.rs
@@ -406,7 +406,7 @@ where
         self.core
             .push_ref(&self.slots, &self.recycle)
             .map_err(|e| match e {
-                crate::mpsc::TrySendError::Full(()) => Full(()),
+                crate::mpsc::errors::TrySendError::Full(()) => Full(()),
                 _ => unreachable!(),
             })
     }

--- a/src/thingbuf.rs
+++ b/src/thingbuf.rs
@@ -387,7 +387,7 @@ where
         self.core
             .push_ref(&*self.slots, &self.recycle)
             .map_err(|e| match e {
-                crate::mpsc::TrySendError::Full(()) => Full(()),
+                crate::mpsc::errors::TrySendError::Full(()) => Full(()),
                 _ => unreachable!(),
             })
     }


### PR DESCRIPTION
This branch improves the MPSC error types a bit:
 - Add some utility methods
 - Add `fmt::Display` impls
 - Make `fmt::Debug` impls not require `T: Debug`
 - Add `std::error::Error` impls when std is enabled
 - Move errors to an `errors` submodule like Tokio's