### PR TITLE
docs: temporarily remove MPSC perf comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ the ring buffer.
 
 - **If you want a high-throughput bounded MPSC channel** that allocates only on
   channel creation. Some MPSC channels have good throughput. Some other MPSC
-  channels won't allocate memory per-waiter. [`thingbuf::mpsc`] has both. See
-  [here](../mpsc_perf_comparison) for a detailed performance comparison of MPSC
-  channels. [`thingbuf::mpsc`] is a competitive choice for a general-purpose
+  channels won't allocate memory per-waiter. [`thingbuf::mpsc`] has both.
+  [`thingbuf::mpsc`] is a competitive choice for a general-purpose
   MPSC channel in most use cases.
 
   Both [asynchronous][`thingbuf::mpsc`] and [blocking][`thingbuf::mpsc::sync`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,11 @@ mod wait;
 
 pub use self::recycling::Recycle;
 
-#[doc = include_str!("../mpsc_perf_comparison.md")]
-pub mod mpsc_perf_comparison {
-    // Empty module, used only for documentation.
-}
+// TODO(eliza): finish writing this
+// #[doc = include_str!("../mpsc_perf_comparison.md")]
+// pub mod mpsc_perf_comparison {
+//     // Empty module, used only for documentation.
+// }
 
 feature! {
     #![all(feature = "static", not(all(loom, test)))]


### PR DESCRIPTION
I haven't quite finished writing this, and it probably deserves to
become a full-fledged blog post. This commit temporarily removes it from
the documentation, because I really want to go ahead and publish v0.1.0
without having to write a bunch more stuff...

Signed-off-by: Eliza Weisman <eliza@buoyant.io>