### PR TITLE
chore(ci): remove wrong test job that never ran

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         # test all Rust versions on Ubuntu
         rust: [stable, 1.57.0]
-        os: [ubuntu-latest, m]
+        os: [ubuntu-latest]
         # test stable Rust on Windows and MacOS as well
         include:
           - rust: stable


### PR DESCRIPTION
Due to a typo, we were accidentally trying to run tests on the operating
system "m". Since GitHub Actions doesn't have runners running the "m"
operating system (because, as far as I know, it doesn't actually
'exist'), this test job would never actually run.

I don't know how this ended up getting merged to main, I really thought
I fixed it on the branch? But, whatever...

Signed-off-by: Eliza Weisman <eliza@buoyant.io>