### PR TITLE
fix: compilation errors with `--no-default-features`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,9 +33,9 @@ jobs:
         override: true
         components: rustfmt
       uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --features alloc
+      with:
+        command: check
+        args: --no-default-features --features alloc
 
   tests:
     name: Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ name: Tests
 jobs:
   build_no_std:
     name: cargo check (no-std)
-    runs_on: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Install toolchain

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,22 @@ env:
 
 name: Tests
 jobs:
+  build_no_std:
+    name: cargo check (no-std)
+    runs_on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: rustfmt
+      uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --no-default-features --features alloc
 
   tests:
     name: Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,10 @@ env:
 name: Tests
 jobs:
   build_no_std:
-    name: cargo check (no-std)
+    name: Check no_std
+    strategy:
+      matrix:
+        feature: [alloc, static]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -35,7 +38,7 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --no-default-features --features alloc
+        args: --no-default-features --features ${{ matrix.feature }}
 
   tests:
     name: Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         toolchain: stable
         override: true
         components: rustfmt
-      uses: actions-rs/cargo@v1
+    - uses: actions-rs/cargo@v1
       with:
         command: check
         args: --no-default-features --features alloc

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ impl Core {
 
     fn close(&self) -> bool {
         test_println!("Core::close");
-        if std::thread::panicking() {
+        if crate::util::panic::panicking() {
             return false;
         }
         test_dbg!(self.tail.fetch_or(self.closed, SeqCst) & self.closed == 0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,7 +516,7 @@ unsafe impl<T: Send> Sync for Ref<'_, T> {}
 
 impl<T> Slot<T> {
     #[cfg(feature = "alloc")]
-    pub(crate) fn make_boxed_array(capacity: usize) -> Box<[Self]> {
+    pub(crate) fn make_boxed_array(capacity: usize) -> alloc::boxed::Box<[Self]> {
         (0..capacity).map(|i| Slot::new(i)).collect()
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -95,29 +95,32 @@ macro_rules! fmt_bits {
 
 #[allow(unused_macros)]
 macro_rules! unreachable_unchecked {
+    (@inner $msg:expr) => {
+        {
+            #[cfg(debug_assertions)] {
+                panic!(
+                    "internal error: entered unreachable code{}\n\n\
+                    /!\\ EXTREMELY SERIOUS WARNING /!\\\n
+                    This code should NEVER be entered; in release mode, this would \
+                    have been an `unreachable_unchecked` hint. The fact that this \
+                    occurred means something VERY bad is going on. \n\
+                    Please contact the `thingbuf` maintainers immediately. Sorry!",
+                    $msg,
+                );
+            }
+            #[cfg(not(debug_assertions))]
+            unsafe {
+                core::hint::unreachable_unchecked();
+            }
+
+        }
+    };
+
     ($($arg:tt)+) => {
-        crate::unreachable_unchecked!(@inner , format_args!(": {}", format_args!($($arg)*)))
+        unreachable_unchecked!(@inner format_args!(": {}", format_args!($($arg)*)))
     };
 
     () => {
-        crate::unreachable_unchecked!(@inner ".")
-    };
-
-    (@inner $msg:expr) => {
-        #[cfg(debug_assertions)] {
-            panic!(
-                "internal error: entered unreachable code{}\n\n\
-                /!\\ EXTREMELY SERIOUS WARNING /!\\\n
-                This code should NEVER be entered; in release mode, this would \
-                have been an `unreachable_unchecked` hint. The fact that this \
-                occurred means something VERY bad is going on. \n\
-                Please contact the `thingbuf` maintainers immediately. Sorry!",
-                $msg,
-            );
-        }
-        #[cfg(not(debug_assertions))]
-        unsafe {
-            core::hint::unreachable_unchecked();
-        }
+        unreachable_unchecked!(@inner ".")
     };
 }

--- a/src/mpsc/async_impl.rs
+++ b/src/mpsc/async_impl.rs
@@ -17,6 +17,7 @@ feature! {
     #![feature = "alloc"]
 
     use crate::loom::sync::Arc;
+    use alloc::boxed::Box;
 
     /// Returns a new asynchronous multi-producer, single consumer (MPSC)
     /// channel with the provided capacity.

--- a/src/util/mutex/spin_impl.rs
+++ b/src/util/mutex/spin_impl.rs
@@ -28,6 +28,7 @@ pub(crate) const fn const_mutex<T>(data: T) -> Mutex<T> {
 }
 
 impl<T> Mutex<T> {
+    #[cfg(loom)]
     pub(crate) fn new(data: T) -> Self {
         Self {
             locked: AtomicBool::new(false),

--- a/src/util/panic.rs
+++ b/src/util/panic.rs
@@ -21,7 +21,7 @@ mod inner {
         Ok(f())
     }
 
-    pub(crate) fn resume_unwind(payload: ()) -> ! {
+    pub(crate) fn resume_unwind(_: ()) -> ! {
         unreachable_unchecked!("code compiled with no_std cannot unwind!")
     }
 }


### PR DESCRIPTION
This fixes compilation for no-std targets. My bad --- I was checking
this manually and never added a CI job for it.

This branch adds a CI check that the crate compiles with
`--no-default-features`, and fixes a number of issues that broke the
no-std build:

* f8d9527 fix(no_std): fix warning in `resume_unwind`
* cbf943a fix(no_std): fix compilation error in `unreachable_unchecked`
* 8ae178a fix(no_std): remove use of `thread::panicking`
* dab0d49 fix(alloc): fix missing `Box` imports
* 208defc fix(no_std): wrong feature gate for println macros

Fixes #58