### PR TITLE
chore: add test for mpsc::try_recv_ref, enable some loom tests

### DIFF
--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -26,8 +26,9 @@ jobs:
         model:
           - mpsc_send_recv_wrap
           - mpsc_try_send_recv
-          - mpsc::rx_close_unconsumed
-          - mpsc_sync::rx_close_unconsumed
+          - mpsc_try_recv_ref
+          - mpsc_async::rx_close_unconsumed
+          - mpsc_blocking::rx_close_unconsumed
     name: model '${{ matrix.model }}''
     runs-on: ubuntu-latest
     steps:
@@ -54,7 +55,7 @@ jobs:
         scope:
           # NOTE: if adding loom models in a new module, that module needs to be
           # added to this list!
-          - mpsc_sync
+          - mpsc_blocking
           - mpsc_async
           - thingbuf
           - util

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ lto = true
 opt-level = 3
 
 [patch.crates-io]
-loom = { git = "https://github.com/tokio-rs/loom", rev = "555b52fdb267964f0950a52be87b0f28c40b054c" }
+loom = { git = "https://github.com/tokio-rs/loom", rev = "a93bf2390e0fcfdb7c5899b31db0e4e795ab4aab" }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
- add a simple test for try_recv_ref
- changes `mpsc_sync ` in `loom.yml` to `mpsc_blocking `, make CI works
- also enable some tests blocked by [tokio-rs/loom#246](https://github.com/tokio-rs/loom/issues/246)