### PR TITLE
style: fix `clippy::needless_borrow` lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,7 +430,7 @@ impl<T> Ref<'_, T> {
             // initialized.
             // TODO(eliza): use `MaybeUninit::assume_init_ref` here once it's
             // supported by `tracing-appender`'s MSRV.
-            f(&*(&*value).as_ptr())
+            f(&*(*value).as_ptr())
         })
     }
 
@@ -441,7 +441,7 @@ impl<T> Ref<'_, T> {
             // slot.
             // TODO(eliza): use `MaybeUninit::assume_init_mut` here once it's
             // supported by `tracing-appender`'s MSRV.
-            f(&mut *(&mut *value).as_mut_ptr())
+            f(&mut *(*value).as_mut_ptr())
         })
     }
 }


### PR DESCRIPTION
This commit fixes the [`clippy::needless_borrow`][1] lints which were added in a recent Clippy version.

[1]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow