### PR TITLE
feat(blocking::mpsc): add `Receiver::recv(_ref)_timeout` methods

### DIFF
--- a/src/mpsc/blocking.rs
+++ b/src/mpsc/blocking.rs
@@ -615,6 +615,7 @@ feature! {
         ///     rx.recv_ref_timeout(Duration::from_millis(100)).as_deref().map(String::as_str)
         /// );
         /// ```
+        #[cfg(not(all(test, loom)))]
         pub fn recv_ref_timeout(&self, timeout: Duration) -> Result<RecvRef<'_, T>, RecvTimeoutError> {
             recv_ref_timeout(self.core, self.slots, timeout)
         }
@@ -669,6 +670,7 @@ feature! {
         ///     rx.recv_timeout(Duration::from_millis(100))
         /// );
         /// ```
+        #[cfg(not(all(test, loom)))]
         pub fn recv_timeout(&self, timeout: Duration) -> Result<T, RecvTimeoutError>
         where
             R: Recycle<T>,
@@ -1175,6 +1177,7 @@ impl<T, R> Receiver<T, R> {
     ///     rx.recv_ref_timeout(Duration::from_millis(100)).as_deref().map(String::as_str)
     /// );
     /// ```
+    #[cfg(not(all(test, loom)))]
     pub fn recv_ref_timeout(&self, timeout: Duration) -> Result<RecvRef<'_, T>, RecvTimeoutError> {
         recv_ref_timeout(&self.inner.core, self.inner.slots.as_ref(), timeout)
     }
@@ -1229,6 +1232,7 @@ impl<T, R> Receiver<T, R> {
     ///     rx.recv_timeout(Duration::from_millis(100))
     /// );
     /// ```
+    #[cfg(not(all(test, loom)))]
     pub fn recv_timeout(&self, timeout: Duration) -> Result<T, RecvTimeoutError>
     where
         R: Recycle<T>,
@@ -1369,6 +1373,7 @@ fn recv_ref<'a, T>(core: &'a ChannelCore<Thread>, slots: &'a [Slot<T>]) -> Optio
     }
 }
 
+#[cfg(not(all(test, loom)))]
 #[inline]
 fn recv_ref_timeout<'a, T>(
     core: &'a ChannelCore<Thread>,

--- a/src/mpsc/blocking.rs
+++ b/src/mpsc/blocking.rs
@@ -629,13 +629,13 @@ feature! {
         /// and replaced with a new slot according to the configured [recycling
         /// policy]. If all [`StaticSender`]s for this channel write to the
         /// channel's slots in place by using the [`send_ref`] or
-        /// [`try_send_ref`] methods, consider using the [`recv_timeout_ref`]
+        /// [`try_send_ref`] methods, consider using the [`recv_ref_timeout`]
         /// method instead, to enable the reuse of heap allocations.
         ///
         /// [`send_ref`]: StaticSender::send_ref
         /// [`try_send_ref`]: StaticSender::try_send_ref
         /// [recycling policy]: crate::recycling::Recycle
-        /// [`recv_timeout_ref`]: Self::recv_timeout_ref
+        /// [`recv_ref_timeout`]: Self::recv_ref_timeout
         ///
         /// # Returns
         ///
@@ -1180,28 +1180,28 @@ impl<T, R> Receiver<T, R> {
     }
 
     /// Receives the next message for this receiver, **by value**, waiting for at most `timeout`.
-        ///
-        /// If there are no messages in the channel's buffer, but the channel
-        /// has not yet been closed, this method will block until a message is
-        /// sent, the channel is closed, or the provided `timeout` has elapsed.
-        ///
-        /// When a message is received, it is moved out of the channel by value,
-        /// and replaced with a new slot according to the configured [recycling
-        /// policy]. If all [`Sender`]s for this channel write to the
-        /// channel's slots in place by using the [`send_ref`] or
-        /// [`try_send_ref`] methods, consider using the [`recv_timeout_ref`]
-        /// method instead, to enable the reuse of heap allocations.
-        ///
-        /// [`send_ref`]: Sender::send_ref
-        /// [`try_send_ref`]: Sender::try_send_ref
-        /// [recycling policy]: crate::recycling::Recycle
-        /// [`recv_timeout_ref`]: Self::recv_timeout_ref
-        ///
-        /// # Returns
-        ///
-        /// - [`Ok`]`(<T>)` if a message was received.
-        /// - [`Err`]`(`[`RecvTimeoutError::Timeout`]`)` if the timeout has elapsed.
-        /// - [`Err`]`(`[`RecvTimeoutError::Closed`]`)` if the channel has closed.
+    ///
+    /// If there are no messages in the channel's buffer, but the channel
+    /// has not yet been closed, this method will block until a message is
+    /// sent, the channel is closed, or the provided `timeout` has elapsed.
+    ///
+    /// When a message is received, it is moved out of the channel by value,
+    /// and replaced with a new slot according to the configured [recycling
+    /// policy]. If all [`Sender`]s for this channel write to the
+    /// channel's slots in place by using the [`send_ref`] or
+    /// [`try_send_ref`] methods, consider using the [`recv_ref_timeout`]
+    /// method instead, to enable the reuse of heap allocations.
+    ///
+    /// [`send_ref`]: Sender::send_ref
+    /// [`try_send_ref`]: Sender::try_send_ref
+    /// [recycling policy]: crate::recycling::Recycle
+    /// [`recv_ref_timeout`]: Self::recv_ref_timeout
+    ///
+    /// # Returns
+    ///
+    /// - [`Ok`]`(<T>)` if a message was received.
+    /// - [`Err`]`(`[`RecvTimeoutError::Timeout`]`)` if the timeout has elapsed.
+    /// - [`Err`]`(`[`RecvTimeoutError::Closed`]`)` if the channel has closed.
     ///
     /// # Examples
     ///

--- a/src/mpsc/blocking.rs
+++ b/src/mpsc/blocking.rs
@@ -576,8 +576,16 @@ feature! {
         }
 
         /// Receives the next message for this receiver, **by reference**, waiting for at most `timeout`.
-        /// Returns an error if the corresponding channel has hung up, or if it waits more than `timeout`.
         ///
+        /// If there are no messages in the channel's buffer, but the channel has
+        /// not yet been closed, this method will block until a message is sent,
+        /// the channel is closed, or the provided `timeout` has elapsed.
+        ///
+        /// # Returns
+        ///
+        /// - [`Ok`]`(`[`RecvRef`]`<T>)` if a message was received.
+        /// - [`Err`]`(`[`RecvTimeoutError::Timeout`]`)` if the timeout has elapsed.
+        /// - [`Err`]`(`[`RecvTimeoutError::Closed`]`)` if the channel has closed.
         /// # Examples
         ///
         /// ```
@@ -612,8 +620,28 @@ feature! {
         }
 
         /// Receives the next message for this receiver, **by value**, waiting for at most `timeout`.
-        /// Returns an error if the corresponding channel has hung up, or if it waits more than `timeout`.
         ///
+        /// If there are no messages in the channel's buffer, but the channel
+        /// has not yet been closed, this method will block until a message is
+        /// sent, the channel is closed, or the provided `timeout` has elapsed.
+        ///
+        /// When a message is received, it is moved out of the channel by value,
+        /// and replaced with a new slot according to the configured [recycling
+        /// policy]. If all [`StaticSender`]s for this channel write to the
+        /// channel's slots in place by using the [`send_ref`] or
+        /// [`try_send_ref`] methods, consider using the [`recv_timeout_ref`]
+        /// method instead, to enable the reuse of heap allocations.
+        ///
+        /// [`send_ref`]: StaticSender::send_ref
+        /// [`try_send_ref`]: StaticSender::try_send_ref
+        /// [recycling policy]: crate::recycling::Recycle
+        /// [`recv_timeout_ref`]: Self::recv_timeout_ref
+        ///
+        /// # Returns
+        ///
+        /// - [`Ok`]`(<T>)` if a message was received.
+        /// - [`Err`]`(`[`RecvTimeoutError::Timeout`]`)` if the timeout has elapsed.
+        /// - [`Err`]`(`[`RecvTimeoutError::Closed`]`)` if the channel has closed.
         /// # Examples
         ///
         /// ```
@@ -1109,8 +1137,16 @@ impl<T, R> Receiver<T, R> {
     }
 
     /// Receives the next message for this receiver, **by reference**, waiting for at most `timeout`.
-    /// Returns an error if the corresponding channel has hung up, or if it waits more than `timeout`.
     ///
+    /// If there are no messages in the channel's buffer, but the channel has
+    /// not yet been closed, this method will block until a message is sent,
+    /// the channel is closed, or the provided `timeout` has elapsed.
+    ///
+    /// # Returns
+    ///
+    /// - [`Ok`]`(`[`RecvRef`]`<T>)` if a message was received.
+    /// - [`Err`]`(`[`RecvTimeoutError::Timeout`]`)` if the timeout has elapsed.
+    /// - [`Err`]`(`[`RecvTimeoutError::Closed`]`)` if the channel has closed.
     /// # Examples
     ///
     /// ```
@@ -1144,7 +1180,28 @@ impl<T, R> Receiver<T, R> {
     }
 
     /// Receives the next message for this receiver, **by value**, waiting for at most `timeout`.
-    /// Returns an error if the corresponding channel has hung up, or if it waits more than `timeout`.
+        ///
+        /// If there are no messages in the channel's buffer, but the channel
+        /// has not yet been closed, this method will block until a message is
+        /// sent, the channel is closed, or the provided `timeout` has elapsed.
+        ///
+        /// When a message is received, it is moved out of the channel by value,
+        /// and replaced with a new slot according to the configured [recycling
+        /// policy]. If all [`Sender`]s for this channel write to the
+        /// channel's slots in place by using the [`send_ref`] or
+        /// [`try_send_ref`] methods, consider using the [`recv_timeout_ref`]
+        /// method instead, to enable the reuse of heap allocations.
+        ///
+        /// [`send_ref`]: Sender::send_ref
+        /// [`try_send_ref`]: Sender::try_send_ref
+        /// [recycling policy]: crate::recycling::Recycle
+        /// [`recv_timeout_ref`]: Self::recv_timeout_ref
+        ///
+        /// # Returns
+        ///
+        /// - [`Ok`]`(<T>)` if a message was received.
+        /// - [`Err`]`(`[`RecvTimeoutError::Timeout`]`)` if the timeout has elapsed.
+        /// - [`Err`]`(`[`RecvTimeoutError::Closed`]`)` if the channel has closed.
     ///
     /// # Examples
     ///

--- a/src/mpsc/errors.rs
+++ b/src/mpsc/errors.rs
@@ -21,10 +21,25 @@ pub enum TrySendError<T = ()> {
     Closed(T),
 }
 
-/// Error returned by the [`Receiver::recv`] and [`Receiver::recv_ref`] methods.
+/// Error returned by the [`Receiver::recv_timeout`] and [`Receiver::recv_ref_timeout`] methods
+/// (blocking only).
 ///
-/// [`Receiver::recv`]: super::Receiver::recv
-/// [`Receiver::recv_ref`]: super::Receiver::recv_ref
+/// [`Receiver::recv_timeout`]: super::blocking::Receiver::recv_timeout
+/// [`Receiver::recv_ref_timeout`]: super::blocking::Receiver::recv_ref_timeout
+#[cfg(feature = "std")]
+#[non_exhaustive]
+#[derive(Debug, PartialEq, Eq)]
+pub enum RecvTimeoutError {
+    /// The timeout elapsed before data could be received.
+    Timeout,
+    /// The channel is closed.
+    Closed,
+}
+
+/// Error returned by the [`Receiver::try_recv`] and [`Receiver::try_recv_ref`] methods.
+///
+/// [`Receiver::try_recv`]: super::Receiver::try_recv
+/// [`Receiver::try_recv_ref`]: super::Receiver::try_recv_ref
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Eq)]
 pub enum TryRecvError {
@@ -137,6 +152,21 @@ impl<T> fmt::Display for TrySendError<T> {
 
 #[cfg(feature = "std")]
 impl<T> std::error::Error for TrySendError<T> {}
+
+// === impl RecvTimeoutError ===
+
+#[cfg(feature = "std")]
+impl std::error::Error for RecvTimeoutError {}
+
+#[cfg(feature = "std")]
+impl fmt::Display for RecvTimeoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Timeout => "timed out waiting on channel",
+            Self::Closed => "channel closed",
+        })
+    }
+}
 
 // == impl TryRecvError ==
 

--- a/src/thingbuf.rs
+++ b/src/thingbuf.rs
@@ -387,7 +387,7 @@ where
     /// [`push`]: Self::push_ref
     pub fn push_ref(&self) -> Result<Ref<'_, T>, Full> {
         self.core
-            .push_ref(&*self.slots, &self.recycle)
+            .push_ref(&self.slots, &self.recycle)
             .map_err(|e| match e {
                 crate::mpsc::errors::TrySendError::Full(()) => Full(()),
                 _ => unreachable!(),
@@ -459,7 +459,7 @@ where
     /// [`push`]: Self::push
     /// [`pop`]: Self::pop
     pub fn pop_ref(&self) -> Option<Ref<'_, T>> {
-        self.core.pop_ref(&*self.slots).ok()
+        self.core.pop_ref(&self.slots).ok()
     }
 
     /// Dequeue the first element in the queue *by value*, moving it out of the

--- a/src/wait/queue.rs
+++ b/src/wait/queue.rs
@@ -626,7 +626,7 @@ impl<T> List<T> {
     }
 
     fn is_empty(&self) -> bool {
-        self.head == None && self.tail == None
+        self.head.is_none() && self.tail.is_none()
     }
 }
 
@@ -658,7 +658,7 @@ mod tests {
             self.0.store(true, Ordering::SeqCst);
         }
 
-        fn same(&self, &Self(ref other): &Self) -> bool {
+        fn same(&self, Self(other): &Self) -> bool {
             Arc::ptr_eq(&self.0, other)
         }
     }


### PR DESCRIPTION
Added recv_timeout methods for blocking::mpsc::Receiver/StaticReceiver. It requires a simple change from `thread::park` to `thread::park_timeout` & an elapsed time check.
We need this functionality so that our threads can wake up at least once every few seconds to check for control events