### PR TITLE
chore: prepare to release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+<a name="v0.1.4"></a>
+## v0.1.4 (2023-04-26)
+
+#### Features
+
+* **blocking::mpsc:**  add `Receiver::recv(_ref)_timeout` methods (#75) ([b57ce88a](https://github.com/hawkw/thingbuf/commit/b57ce88ac85cf71b363035249e27f1c91e65f372))
+
+#### Bug Fixes
+
+* **blocking::mpsc:**  increase durations in doctests (#78) ([465fd3cb](https://github.com/hawkw/thingbuf/commit/465fd3cbcb411a4413f382afcdfab1e5d68f3a4a))
+
+
+
 <a name="v0.1.3"></a>
 ### v0.1.3 (2022-05-13)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "thingbuf"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.57.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]


### PR DESCRIPTION
<a name=""></a>
##  (2023-04-26)

#### Features

* **blocking::mpsc:**  add `Receiver::recv(_ref)_timeout` methods (#75) ([b57ce88a](https://github.com/hawkw/thingbuf/commit/b57ce88ac85cf71b363035249e27f1c91e65f372))