### PR TITLE
Skip slots with active reading `Ref`s

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@ impl Core {
                     continue;
                 }
 
-                // The slot is in invalid state (was skipped). Try to advance the head index.
+                // The slot is in an invalid state (was skipped). Try to advance the head index.
                 match test_dbg!(self
                     .head
                     .compare_exchange_weak(head, next_head, SeqCst, Acquire))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,8 +182,8 @@ impl Core {
         slots: &'slots [Slot<T>],
         recycle: &R,
     ) -> Result<Ref<'slots, T>, TrySendError<()>>
-        where
-            R: Recycle<T>,
+    where
+        R: Recycle<T>,
     {
         test_println!("push_ref");
         let mut backoff = Backoff::new();

--- a/src/mpsc/tests/mpsc_blocking.rs
+++ b/src/mpsc/tests/mpsc_blocking.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::loom::{self, alloc::Track, thread};
+use crate::mpsc::blocking;
+use crate::mpsc::blocking::RecvRef;
 
 #[test]
 #[cfg_attr(ci_skip_slow_models, ignore)]
@@ -59,6 +61,60 @@ fn mpsc_try_recv_ref() {
                 Ok(val) => vals.push(*val),
                 Err(TryRecvError::Empty) => {}
                 Err(TryRecvError::Closed) => panic!("channel closed"),
+            }
+            thread::yield_now();
+        }
+
+        vals.sort_unstable();
+        assert_eq_dbg!(vals, vec![1, 2, 3, 4]);
+
+        p1.join().unwrap();
+        p2.join().unwrap();
+    })
+}
+
+#[test]
+#[cfg_attr(ci_skip_slow_models, ignore)]
+fn mpsc_test_skip_slot() {
+    loom::model(|| {
+        let (tx, rx) = blocking::channel(2);
+
+        let p1 = {
+            let tx = tx.clone();
+            thread::spawn(move || {
+                *tx.send_ref().unwrap() = 1;
+                thread::yield_now();
+                *tx.send_ref().unwrap() = 2;
+            })
+        };
+
+        let p2 = {
+            thread::spawn(move || {
+                *tx.send_ref().unwrap() = 3;
+                thread::yield_now();
+                *tx.send_ref().unwrap() = 4;
+            })
+        };
+
+        let mut vals = Vec::new();
+        let mut hold: Vec<RecvRef<usize>> = Vec::new();
+
+        while vals.len() < 4 {
+            match rx.try_recv_ref() {
+                Ok(val) => {
+                    if vals.len() == 2 && !hold.is_empty() {
+                        vals.push(*hold.pop().unwrap());
+                        vals.push(*val);
+                    } else if vals.len() == 1 && hold.is_empty() {
+                        hold.push(val);
+                    } else {
+                        vals.push(*val);
+                    }
+                }
+                Err(TryRecvError::Empty) => {}
+                Err(TryRecvError::Closed) => {
+                    panic!("channel closed");
+                },
             }
             thread::yield_now();
         }
@@ -324,6 +380,41 @@ fn spsc_send_recv_in_order_wrap() {
         drop(tx);
         consumer.join().unwrap();
     })
+}
+
+#[test]
+fn spsc_send_recv_in_order_skip_wrap() {
+    const N_SENDS: usize = 5;
+    loom::model(|| {
+        let (tx, rx) = blocking::channel::<usize>((N_SENDS + 1) / 2);
+        let consumer = thread::spawn(move || {
+            let mut hold = Vec::new();
+            assert_eq_dbg!(rx.recv(), Some(1));
+            loop {
+                match rx.try_recv_ref() {
+                    Ok(val) => {
+                        assert_eq_dbg!(*val, 2);
+                        hold.push(val);
+                        break;
+                    },
+                    Err(TryRecvError::Empty) => {
+                        loom::thread::yield_now();
+                    },
+                    Err(TryRecvError::Closed) => panic!("channel closed"),
+                }
+            }
+            for i in 3..=N_SENDS {
+                assert_eq_dbg!(rx.recv(), Some(i));
+            }
+            assert_eq_dbg!(rx.recv(), None);
+
+        });
+        for i in 1..=N_SENDS {
+            tx.send(i).unwrap();
+        }
+        drop(tx);
+        consumer.join().unwrap();
+    });
 }
 
 #[test]

--- a/tests/mpsc_blocking.rs
+++ b/tests/mpsc_blocking.rs
@@ -1,5 +1,6 @@
 use std::thread;
 use thingbuf::mpsc::blocking;
+use thingbuf::mpsc::errors::{TryRecvError, TrySendError};
 
 #[test]
 fn basically_works() {
@@ -70,3 +71,55 @@ fn tx_close_drains_queue() {
         producer.join().unwrap();
     }
 }
+
+#[test]
+fn spsc_skip_slot() {
+    let (tx, rx) = blocking::channel::<usize>(3);
+    // 0 lap
+    tx.send(0).unwrap();
+    assert_eq!(rx.recv(), Some(0));
+    tx.send(1).unwrap();
+    let msg_ref = rx.try_recv_ref().unwrap();
+    tx.send(2).unwrap();
+    assert_eq!(rx.recv(), Some(2));
+    // 1 lap
+    tx.send(3).unwrap();
+    assert_eq!(rx.recv(), Some(3));
+    tx.send(4).unwrap();
+    assert_eq!(rx.recv(), Some(4));
+    drop(msg_ref);
+    // 2 lap
+    tx.send(5).unwrap();
+    tx.send(6).unwrap();
+    tx.send(7).unwrap();
+    assert!(matches!(tx.try_send_ref(), Err(TrySendError::Full(_))));
+    assert_eq!(rx.recv(), Some(5));
+    assert_eq!(rx.recv(), Some(6));
+    assert_eq!(rx.recv(), Some(7));
+}
+
+#[test]
+fn spsc_full_after_skipped() {
+    let (tx, rx) = blocking::channel::<usize>(3);
+    // 0 lap
+    tx.send(0).unwrap();
+    assert_eq!(rx.recv(), Some(0));
+    tx.send(1).unwrap();
+    let _msg_ref = rx.try_recv_ref().unwrap();
+    tx.send(2).unwrap();
+    // lap 1
+    tx.send(3).unwrap();
+    assert!(matches!(tx.try_send_ref(), Err(TrySendError::Full(_))));
+}
+
+#[test]
+fn spsc_empty_after_skipped() {
+    let (tx, rx) = blocking::channel::<usize>(2);
+    // 0 lap
+    tx.send(0).unwrap();
+    tx.send(1).unwrap();
+    let _msg_ref = rx.try_recv_ref().unwrap();
+    assert_eq!(rx.recv(), Some(1));
+    assert!(matches!(rx.try_recv_ref(), Err(TryRecvError::Empty)));
+}
+

--- a/tests/mpsc_blocking.rs
+++ b/tests/mpsc_blocking.rs
@@ -122,4 +122,3 @@ fn spsc_empty_after_skipped() {
     assert_eq!(rx.recv(), Some(1));
     assert!(matches!(rx.try_recv_ref(), Err(TryRecvError::Empty)));
 }
-


### PR DESCRIPTION
`Core::push_ref` can go into an (almost infinite) spin loop waiting for a `Ref` (created in `pop_ref`) to this slot to be dropped. This behaviour can lead to writing being blocked unless all refs are dropped, even if we have free space in the buffer. 

In this PR I propose a mechanism to skip such slots (by updating their `state`) and attempt to write into them on the next lap. 