### PR TITLE
Add the ability to construct StaticChannels with a recycle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,6 @@ loom = { git = "https://github.com/tokio-rs/loom", rev = "a93bf2390e0fcfdb7c5899
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)', 'cfg(thingbuf_trace)'] }

--- a/src/mpsc/async_impl.rs
+++ b/src/mpsc/async_impl.rs
@@ -936,16 +936,26 @@ feature! {
         /// [`split`]: StaticChannel::split
         #[must_use]
         pub const fn new() -> Self {
-            Self {
-                core: ChannelCore::new(CAPACITY),
-                slots: Slot::make_static_array::<CAPACITY>(),
-                is_split: AtomicBool::new(false),
-                recycle: recycling::DefaultRecycle::new(),
-            }
+            Self::with_recycle(recycling::DefaultRecycle::new())
         }
     }
 
     impl<T, R, const CAPACITY: usize> StaticChannel<T, CAPACITY, R> {
+        /// Constructs a new statically-allocated, asynchronous bounded MPSC channel
+        /// with the provided [recycling policy].
+        ///
+        /// See [`Self::new`] for more information.
+        ///
+        /// [recycling policy]: crate::recycling::Recycle
+        #[must_use]
+        pub const fn with_recycle(recycle: R) -> Self {
+            Self {
+                core: ChannelCore::new(CAPACITY),
+                slots: Slot::make_static_array::<CAPACITY>(),
+                is_split: AtomicBool::new(false),
+                recycle,
+            }
+        }
         /// Split a [`StaticChannel`] into a [`StaticSender`]/[`StaticReceiver`]
         /// pair.
         ///

--- a/src/mpsc/blocking.rs
+++ b/src/mpsc/blocking.rs
@@ -196,16 +196,27 @@ feature! {
         /// [`split`]: StaticChannel::split
         #[must_use]
         pub const fn new() -> Self {
-            Self {
-                core: ChannelCore::new(CAPACITY),
-                slots: Slot::make_static_array::<CAPACITY>(),
-                is_split: AtomicBool::new(false),
-                recycle: recycling::DefaultRecycle::new(),
-            }
+            Self::with_recycle(recycling::DefaultRecycle::new())
         }
     }
 
     impl<T, R, const CAPACITY: usize> StaticChannel<T, CAPACITY, R> {
+        /// Constructs a new statically-allocated, blocking bounded MPSC channel
+        /// with the provided [recycling policy].
+        /// 
+        /// See [`Self::new`] for more information.
+        ///
+        /// [recycling policy]: crate::recycling::Recycle
+        #[must_use]
+        pub const fn with_recycle(recycle: R) -> Self {
+            Self {
+                core: ChannelCore::new(CAPACITY),
+                slots: Slot::make_static_array::<CAPACITY>(),
+                is_split: AtomicBool::new(false),
+                recycle,
+            }
+        }
+
         /// Split a [`StaticChannel`] into a [`StaticSender`]/[`StaticReceiver`]
         /// pair.
         ///


### PR DESCRIPTION
There wasn't actually a way to create a `StaticChannel` with a non-default recycle policy. This adds a `with_recycle` associated function for both async and blocking `StaticChannel`s